### PR TITLE
Update npm publishing workflow to use Node.js 24 and streamline build…

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -6,25 +6,20 @@ on:
     types: [completed]
 
 permissions:
+  id-token: write  # Required for OIDC
   contents: read
-  id-token: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Set version from package.json
-        run: echo "Version already set in package.json"
-
-      - name: Publish to npm
-        run: npm publish --provenance --access public
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test
+      - run: npm publish


### PR DESCRIPTION
… process

- Changed Node.js version from 20 to 24.
- Removed unnecessary steps for setting version from package.json and publishing.
- Added steps for installing dependencies, building the project, and running tests before publishing to npm.