### PR TITLE
Fix npm publish workflow: replace npm ci with npm install

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
+      - run: npm install --ignore-scripts
       - run: npm run build --if-present
       - run: npm test
       - run: npm publish


### PR DESCRIPTION
npm ci requires a package-lock.json which doesn't exist in this repo.