### PR TITLE
Fix ClawHub suspicious flag: declare BRIA_API_KEY in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Official Bria AI skills — text-to-image generation, image editing, background removal and replacement, object removal, inpainting, outpainting, upscale, restyle, product photography and packshots, batch/bulk generation, VGL structured prompts, and image utilities. Commercially licensed, royalty-free, brand-safe AI image generation and editing API.",
-    "version": "1.2.4",
+    "version": "1.2.5",
     "repository": "https://github.com/bria-ai/bria-skill",
     "license": "MIT",
     "keywords": ["image-generation", "ai-images", "bria", "fibo", "rmbg", "background-removal", "background-replacement", "image-editing", "vgl", "product-photography", "packshot", "lifestyle-shot", "visual-assets", "text-to-image", "photo-editing", "transparent-png", "upscale", "outpaint", "inpaint", "object-removal", "restyle", "e-commerce", "marketing", "marketing-visuals", "social-media", "thumbnail", "banner", "hero-image", "ad-creative", "photo-restoration", "style-transfer", "royalty-free", "commercial-license", "brand-safe", "batch-generation", "bulk-generation", "image-variations", "compositing", "image-api", "pipeline", "visual-content-creation"]
@@ -20,6 +20,13 @@
       "strict": false,
       "skills": [
         "./skills/bria-ai"
+      ],
+      "dependencies": [
+        {
+          "type": "env",
+          "name": "BRIA_API_KEY",
+          "description": "Bria AI API key (get one at https://platform.bria.ai/console/account/api-keys)"
+        }
       ],
       "author": {
         "name": "Bria AI"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bria-skills",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Official Bria AI skills for Claude Code - image generation, editing, background removal, VGL structured prompts, and image utilities",
   "bin": {
     "bria-skills": "bin/cli.js"

--- a/skills/bria-ai/SKILL.md
+++ b/skills/bria-ai/SKILL.md
@@ -5,7 +5,7 @@ homepage: https://bria.ai
 license: MIT
 metadata:
   author: Bria AI
-  version: "1.2.4"
+  version: "1.2.5"
   dependencies:
     - type: env
       name: BRIA_API_KEY
@@ -100,7 +100,7 @@ Then tell the user:
 curl -X POST "https://engine.prod.bria-api.com/v2/image/generate" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "prompt": "your description",
     "aspect_ratio": "16:9",
@@ -123,7 +123,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/generate" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/remove_background" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{"image": "https://..."}'
 ```
 
@@ -135,7 +135,7 @@ Returns PNG with transparency.
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "images": ["https://..."],
     "instruction": "change the mug to red"
@@ -148,7 +148,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/gen_fill" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "image": "https://...",
     "mask": "https://...",
@@ -162,7 +162,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/gen_fill" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/expand" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "image": "base64-or-url",
     "aspect_ratio": "16:9",
@@ -176,7 +176,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/expand" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/increase_resolution" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{"image": "https://...", "scale": 2}'
 ```
 
@@ -186,7 +186,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/increase_resolution
 curl -X POST "https://engine.prod.bria-api.com/v1/product/lifestyle_shot_by_text" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "image": "https://product-with-transparent-bg.png",
     "prompt": "modern kitchen countertop, natural morning light"
@@ -201,7 +201,7 @@ Place one or more products at exact coordinates in a scene. Products are automat
 curl -X POST "https://engine.prod.bria-api.com/image/edit/product/integrate" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "scene": "https://scene-image-url",
     "products": [
@@ -239,7 +239,7 @@ import requests, time
 
 def get_result(status_url, api_key):
     while True:
-        r = requests.get(status_url, headers={"api_token": api_key, "User-Agent": "BriaSkills/1.2.4"})
+        r = requests.get(status_url, headers={"api_token": api_key, "User-Agent": "BriaSkills/1.2.5"})
         data = r.json()
         if data["status"] == "COMPLETED":
             return data["result"]["image_url"]
@@ -332,7 +332,7 @@ All requests need `api_token` header:
 api_token: YOUR_BRIA_API_KEY
 User-Agent: BriaSkills/<version>
 ```
-> **Required:** Always include the `User-Agent: BriaSkills/<version>` header (where `<version>` is the current skill version from `package.json`, e.g. `BriaSkills/1.2.4`) in every API call, including status polling requests.
+> **Required:** Always include the `User-Agent: BriaSkills/<version>` header (where `<version>` is the current skill version from `package.json`, e.g. `BriaSkills/1.2.5`) in every API call, including status polling requests.
 
 ---
 

--- a/skills/bria-ai/references/api-endpoints.md
+++ b/skills/bria-ai/references/api-endpoints.md
@@ -11,7 +11,7 @@ Content-Type: application/json
 User-Agent: BriaSkills/<version>
 ```
 
-> **Required:** Always include the `User-Agent: BriaSkills/<version>` header (where `<version>` is the current skill version from `package.json`, e.g. `BriaSkills/1.2.4`) in every API call, including status polling requests.
+> **Required:** Always include the `User-Agent: BriaSkills/<version>` header (where `<version>` is the current skill version from `package.json`, e.g. `BriaSkills/1.2.5`) in every API call, including status polling requests.
 
 ---
 
@@ -542,7 +542,7 @@ Check async request status.
 import requests, time
 
 def poll(status_url, api_key, timeout=120):
-    headers = {"api_token": api_key, "User-Agent": "BriaSkills/1.2.4"}
+    headers = {"api_token": api_key, "User-Agent": "BriaSkills/1.2.5"}
     for _ in range(timeout // 2):
         r = requests.get(status_url, headers=headers)
         data = r.json()

--- a/skills/bria-ai/references/code-examples/bria_client.py
+++ b/skills/bria-ai/references/code-examples/bria_client.py
@@ -108,7 +108,7 @@ class BriaClient:
         return {
             "api_token": self.api_key,
             "Content-Type": "application/json",
-            "User-Agent": "BriaSkills/1.2.4",
+            "User-Agent": "BriaSkills/1.2.5",
         }
 
     def _request(self, endpoint: str, data: Dict, wait: bool = True) -> Dict[str, Any]:

--- a/skills/bria-ai/references/code-examples/bria_client.sh
+++ b/skills/bria-ai/references/code-examples/bria_client.sh
@@ -25,7 +25,7 @@ BRIA_BASE_URL="${BRIA_BASE_URL:-https://engine.prod.bria-api.com}"
 BRIA_API_KEY="${BRIA_API_KEY:-}"
 BRIA_POLL_INTERVAL="${BRIA_POLL_INTERVAL:-2}"
 BRIA_TIMEOUT="${BRIA_TIMEOUT:-120}"
-BRIA_USER_AGENT="BriaSkills/1.2.4"
+BRIA_USER_AGENT="BriaSkills/1.2.5"
 
 # ==================== Helper Functions ====================
 
@@ -642,7 +642,7 @@ print_curl_examples() {
 curl -X POST "https://engine.prod.bria-api.com/v2/image/generate" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "prompt": "Modern tech startup office, developers collaborating",
     "aspect_ratio": "16:9",
@@ -654,13 +654,13 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/generate" \
 # --- Poll Status (replace STATUS_URL) ---
 curl -X GET "STATUS_URL" \
   -H "api_token: $BRIA_API_KEY" \
-  -H "User-Agent: BriaSkills/1.2.4"
+  -H "User-Agent: BriaSkills/1.2.5"
 
 # --- Remove Background ---
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/remove_background" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "image": "https://example.com/image.jpg"
   }'
@@ -669,7 +669,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/remove_background" 
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/gen_fill" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "image": "https://example.com/image.jpg",
     "mask": "https://example.com/mask.png",
@@ -681,7 +681,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/gen_fill" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/erase" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "image": "https://example.com/image.jpg",
     "mask": "https://example.com/mask.png"
@@ -691,7 +691,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/erase" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/replace_background" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "image": "https://example.com/image.jpg",
     "prompt": "tropical beach at sunset"
@@ -701,7 +701,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/replace_background"
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/expand" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "image": "https://example.com/image.jpg",
     "aspect_ratio": "16:9",
@@ -712,7 +712,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/expand" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/enhance" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "image": "https://example.com/image.jpg"
   }'
@@ -721,7 +721,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/enhance" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/increase_resolution" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "image": "https://example.com/image.jpg",
     "scale": 2
@@ -731,7 +731,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/increase_resolution
 curl -X POST "https://engine.prod.bria-api.com/v1/product/lifestyle_shot_by_text" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "file": "BASE64_ENCODED_IMAGE",
     "prompt": "modern kitchen countertop, morning light",
@@ -742,7 +742,7 @@ curl -X POST "https://engine.prod.bria-api.com/v1/product/lifestyle_shot_by_text
 curl -X POST "https://engine.prod.bria-api.com/image/edit/product/integrate" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "scene": "https://example.com/scene.jpg",
     "products": [
@@ -757,7 +757,7 @@ curl -X POST "https://engine.prod.bria-api.com/image/edit/product/integrate" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "images": ["https://example.com/image.jpg"],
     "instruction": "change the mug to red"
@@ -767,7 +767,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/add_object_by_text" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "image": "https://example.com/image.jpg",
     "instruction": "Place a red vase on the table"
@@ -777,7 +777,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/add_object_by_text"
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/replace_object_by_text" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "image": "https://example.com/image.jpg",
     "instruction": "Replace the red apple with a green pear"
@@ -787,7 +787,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/replace_object_by_t
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/erase_by_text" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "image": "https://example.com/image.jpg",
     "object_name": "table"
@@ -797,7 +797,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/erase_by_text" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/blend" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "image": "https://example.com/base.jpg",
     "overlay": "https://example.com/texture.png",
@@ -808,7 +808,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/blend" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/reseason" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "image": "https://example.com/image.jpg",
     "season": "winter"
@@ -818,7 +818,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/reseason" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/restyle" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "image": "https://example.com/image.jpg",
     "style": "oil_painting"
@@ -828,7 +828,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/restyle" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/relight" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "image": "https://example.com/image.jpg",
     "light_type": "sunrise light",
@@ -839,7 +839,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/relight" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/sketch_to_colored_image" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "image": "https://example.com/sketch.png",
     "prompt": "modern sports car"
@@ -849,7 +849,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/sketch_to_colored_i
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/restore" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "image": "https://example.com/old-photo.jpg"
   }'
@@ -858,7 +858,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/restore" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/colorize" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "image": "https://example.com/bw-photo.jpg",
     "color": "contemporary color"
@@ -868,7 +868,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/colorize" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/crop_foreground" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "image": "https://example.com/image.jpg"
   }'
@@ -877,7 +877,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/crop_foreground" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/blur_background" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "image": "https://example.com/image.jpg"
   }'
@@ -886,7 +886,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/blur_background" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/erase_foreground" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "image": "https://example.com/image.jpg"
   }'

--- a/skills/bria-ai/references/code-examples/bria_client.ts
+++ b/skills/bria-ai/references/code-examples/bria_client.ts
@@ -122,7 +122,7 @@ export class BriaClient {
     return {
       api_token: this.apiKey,
       "Content-Type": "application/json",
-      "User-Agent": "BriaSkills/1.2.4",
+      "User-Agent": "BriaSkills/1.2.5",
     };
   }
 

--- a/skills/bria-ai/references/workflows.md
+++ b/skills/bria-ai/references/workflows.md
@@ -14,7 +14,7 @@ async def generate_image(session, api_key, prompt, aspect_ratio="1:1"):
     """Launch a single generation request."""
     async with session.post(
         "https://engine.prod.bria-api.com/v2/image/generate",
-        headers={"api_token": api_key, "Content-Type": "application/json", "User-Agent": "BriaSkills/1.2.4"},
+        headers={"api_token": api_key, "Content-Type": "application/json", "User-Agent": "BriaSkills/1.2.5"},
         json={"prompt": prompt, "aspect_ratio": aspect_ratio}
     ) as resp:
         return await resp.json()
@@ -22,7 +22,7 @@ async def generate_image(session, api_key, prompt, aspect_ratio="1:1"):
 async def poll_status(session, api_key, status_url, timeout=120):
     """Poll until complete or failed."""
     for _ in range(timeout // 2):
-        async with session.get(status_url, headers={"api_token": api_key, "User-Agent": "BriaSkills/1.2.4"}) as resp:
+        async with session.get(status_url, headers={"api_token": api_key, "User-Agent": "BriaSkills/1.2.5"}) as resp:
             data = await resp.json()
             if data["status"] == "COMPLETED":
                 return data["result"]["image_url"]
@@ -109,14 +109,14 @@ async function generateBatch(
       // Launch request
       const res = await fetch("https://engine.prod.bria-api.com/v2/image/generate", {
         method: "POST",
-        headers: { "api_token": apiKey, "Content-Type": "application/json", "User-Agent": "BriaSkills/1.2.4" },
+        headers: { "api_token": apiKey, "Content-Type": "application/json", "User-Agent": "BriaSkills/1.2.5" },
         body: JSON.stringify({ prompt, aspect_ratio: aspectRatio })
       });
       const { status_url } = (await res.json()) as BriaResponse;
 
       // Poll for result
       for (let i = 0; i < 60; i++) {
-        const statusRes = await fetch(status_url, { headers: { "api_token": apiKey, "User-Agent": "BriaSkills/1.2.4" } });
+        const statusRes = await fetch(status_url, { headers: { "api_token": apiKey, "User-Agent": "BriaSkills/1.2.5" } });
         const data = (await statusRes.json()) as BriaStatusResponse;
         if (data.status === "COMPLETED") return data.result!.image_url;
         if (data.status === "FAILED") throw new Error(data.error || "Generation failed");
@@ -174,7 +174,7 @@ async def product_pipeline(api_key, product_descriptions, scene_prompt):
             # Step 2: Remove background
             async with session.post(
                 "https://engine.prod.bria-api.com/v2/image/edit/remove_background",
-                headers={"api_token": api_key, "Content-Type": "application/json", "User-Agent": "BriaSkills/1.2.4"},
+                headers={"api_token": api_key, "Content-Type": "application/json", "User-Agent": "BriaSkills/1.2.5"},
                 json={"image": product_url}
             ) as resp:
                 rmbg_result = await resp.json()
@@ -183,7 +183,7 @@ async def product_pipeline(api_key, product_descriptions, scene_prompt):
             # Step 3: Place in lifestyle scene
             async with session.post(
                 "https://engine.prod.bria-api.com/v2/image/edit/lifestyle_shot_by_text",
-                headers={"api_token": api_key, "Content-Type": "application/json", "User-Agent": "BriaSkills/1.2.4"},
+                headers={"api_token": api_key, "Content-Type": "application/json", "User-Agent": "BriaSkills/1.2.5"},
                 json={"image": transparent_url, "prompt": scene_prompt}
             ) as resp:
                 lifestyle_result = await resp.json()

--- a/skills/image-utils/SKILL.md
+++ b/skills/image-utils/SKILL.md
@@ -4,7 +4,7 @@ description: Classic image manipulation with Python Pillow - resize, crop, compo
 license: MIT
 metadata:
   author: Bria AI
-  version: "1.2.4"
+  version: "1.2.5"
 ---
 
 # Image Utilities

--- a/skills/image-utils/references/code-examples/image_utils.py
+++ b/skills/image-utils/references/code-examples/image_utils.py
@@ -101,7 +101,7 @@ class ImageUtils:
             PIL Image object
         """
         response = requests.get(
-            url, timeout=timeout, headers={"User-Agent": "BriaSkills/1.2.4"}
+            url, timeout=timeout, headers={"User-Agent": "BriaSkills/1.2.5"}
         )
         response.raise_for_status()
         return Image.open(io.BytesIO(response.content))

--- a/skills/vgl/SKILL.md
+++ b/skills/vgl/SKILL.md
@@ -4,7 +4,7 @@ description: Maximum control over AI image generation — write structured VGL (
 license: MIT
 metadata:
   author: Bria AI
-  version: "1.2.4"
+  version: "1.2.5"
 ---
 
 # Bria VGL — Full Control Over Image Generation
@@ -266,7 +266,7 @@ Only change what the edit strictly requires.
 curl -X POST "https://engine.prod.bria-api.com/v2/image/generate" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.2.4" \
+  -H "User-Agent: BriaSkills/1.2.5" \
   -d '{
     "structured_prompt": "{\"short_description\": \"...\", ...}",
     "prompt": "Generate this scene",


### PR DESCRIPTION
## Summary
- Add `BRIA_API_KEY` dependency to the `bria-ai` plugin entry in `marketplace.json` to fix metadata inconsistency that caused ClawHub's OpenClaw scanner to flag the skill as "Suspicious"
- The registry metadata previously showed "Required env vars: none" while SKILL.md and all code examples require `BRIA_API_KEY` — this mismatch triggered the flag
- Bump version to 1.2.5 across all files

## Test plan
- [ ] Verify `marketplace.json` now declares BRIA_API_KEY dependency under the bria-ai plugin
- [ ] Publish v1.2.5 to npm and confirm ClawHub re-scans and clears the suspicious flag
- [ ] Confirm skill still installs and works correctly with `claude install bria-skills`

🤖 Generated with [Claude Code](https://claude.com/claude-code)