### PR TITLE
Update image-utils to reference bria-ai skill

### DIFF
--- a/skills/image-utils/SKILL.md
+++ b/skills/image-utils/SKILL.md
@@ -242,19 +242,21 @@ with open("optimized.webp", "wb") as f:
     f.write(optimized_bytes)
 ```
 
-## Integration with AI Image Generation
+## Integration with Bria AI
 
-Use with Bria AI or other image generation APIs:
+Use alongside the **[bria-ai skill](../bria-ai/SKILL.md)** to post-process AI-generated images. Generate or edit images with Bria's API, then use image-utils for resizing, cropping, watermarking, and web optimization.
 
 ```python
-from bria_client import BriaClient
+import requests
 from image_utils import ImageUtils
 
-client = BriaClient()
-
-# Generate with AI
-result = client.generate("product photo of headphones", aspect_ratio="1:1")
-image_url = result['result']['image_url']
+# Generate with Bria AI (see bria-ai skill for full API reference)
+response = requests.post(
+    "https://engine.prod.bria-api.com/v2/image/generate",
+    headers={"api_token": BRIA_API_KEY, "Content-Type": "application/json"},
+    json={"prompt": "product photo of headphones", "aspect_ratio": "1:1", "sync": True}
+)
+image_url = response.json()["result"]["image_url"]
 
 # Download and post-process
 image = ImageUtils.load_from_url(image_url)

--- a/skills/image-utils/SKILL.md
+++ b/skills/image-utils/SKILL.md
@@ -244,7 +244,7 @@ with open("optimized.webp", "wb") as f:
 
 ## Integration with Bria AI
 
-Use alongside the **[bria-ai skill](../bria-ai/SKILL.md)** to post-process AI-generated images. Generate or edit images with Bria's API, then use image-utils for resizing, cropping, watermarking, and web optimization.
+Use alongside the **[bria-ai skill](https://clawhub.ai/galbria/bria-ai)** to post-process AI-generated images. Generate or edit images with Bria's API, then use image-utils for resizing, cropping, watermarking, and web optimization.
 
 ```python
 import requests


### PR DESCRIPTION
## Summary
- Replace fictional `BriaClient` import with actual Bria API call matching the bria-ai skill docs
- Add direct link to the bria-ai skill (`../bria-ai/SKILL.md`)
- Include `sync: True` for direct response handling

## Test plan
- [ ] Verify the link to bria-ai skill resolves correctly
- [ ] Confirm the API example matches the bria-ai skill's documented endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)