### PR TITLE
Fix bria-ai skill: remove invalid homepage frontmatter

### DIFF
--- a/skills/bria-ai/SKILL.md
+++ b/skills/bria-ai/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: bria-ai
 description: Generate, edit, create product images with AI. Remove or replace backgrounds, lifestyle shots, transparent PNGs, visual assets, batch generation, illustrations. Controllable image editing with Bria.ai commercially-safe models — fine-grained control over what gets generated, edited, or removed. Edit by text instruction, mask specific regions, add/replace/remove individual objects, control lighting, season, and style. Use for e-commerce product photography, background removal, image upscaling, style transfer, hero images, icons, banners, and pipeline workflows. Triggers on AI image generation, controllable editing, background removal, or visual asset creation.
-homepage: https://bria.ai
 license: MIT
 metadata:
   author: Bria AI


### PR DESCRIPTION
## Summary
- Remove `homepage` field from `skills/bria-ai/SKILL.md` frontmatter — it's not a valid SKILL.md key and was causing validation failures

## Test plan
- [x] Verify `skills-ref validate skills/bria-ai/` passes
- [x] Confirm skill still loads correctly in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)