### PR TITLE
Fix API key exposure in bria-ai skill setup

### DIFF
--- a/skills/bria-ai/SKILL.md
+++ b/skills/bria-ai/SKILL.md
@@ -19,10 +19,14 @@ Generate, edit, and create visual assets using Bria's commercially-safe AI model
 
 Before making any Bria API call, check for the API key and help the user set it up if missing:
 
-### Step 1: Check if the key exists
+### Step 1: Check if the key exists (without printing the key)
 
 ```bash
-echo $BRIA_API_KEY
+if [ -z "$BRIA_API_KEY" ]; then
+  echo "BRIA_API_KEY is not set"
+else
+  echo "BRIA_API_KEY is set"
+fi
 ```
 
 If the output is **not empty**, skip to the next section.


### PR DESCRIPTION
## Summary
- Replaced direct `echo $BRIA_API_KEY` with a safe existence check that reports whether the key is set without printing the secret value
- Prevents accidental API key leakage in terminal output

## Test plan
- [ ] Verify skill setup flow works when `BRIA_API_KEY` is set
- [ ] Verify skill setup flow works when `BRIA_API_KEY` is not set
- [ ] Confirm the key value is never printed to the terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)