### PR TITLE
docs(bria-ai): link full API reference at docs.bria.ai/llms.txt

### DIFF
--- a/skills/bria-ai/SKILL.md
+++ b/skills/bria-ai/SKILL.md
@@ -15,6 +15,8 @@ metadata:
 
 Commercially safe, royalty-free image generation and editing through 20+ API endpoints. Generate from text, edit with natural language, remove backgrounds, create product shots, and build automated image pipelines.
 
+If you are stuck on request shapes, parameters, or endpoints not covered here, **fetch the full agent-oriented API reference** at [docs.bria.ai/llms.txt](https://docs.bria.ai/llms.txt) — it is the canonical LLM-ready documentation and the right place to look before guessing.
+
 ## When to Use This Skill
 
 Use this skill when the user wants to:
@@ -266,7 +268,9 @@ def get_result(status_url, api_key):
 
 ## API Reference
 
-See `references/api-endpoints.md` for complete endpoint documentation with request/response formats for all 20+ endpoints.
+For the **complete** Bria API (all endpoints, fields, and behaviors), use **[docs.bria.ai/llms.txt](https://docs.bria.ai/llms.txt)** — agent-ready docs meant for assistants implementing the API. Reach for it whenever this skill’s summary is not enough.
+
+See `references/api-endpoints.md` for complete endpoint documentation with request/response formats for all 20+ endpoints (in-repo companion to the quick reference above).
 
 ### Authentication
 
@@ -281,6 +285,7 @@ User-Agent: BriaSkills/1.2.7
 
 ## Additional Resources
 
+- **[Agent-ready API reference — llms.txt](https://docs.bria.ai/llms.txt)** — Full Bria API documentation for assistants; use when stuck on implementation details
 - **[API Endpoints Reference](references/api-endpoints.md)** — Complete endpoint documentation with request/response formats
 - **[Workflows & Pipelines](references/workflows.md)** — Batch generation, parallel pipelines, integration examples
 - **[Python Client](references/code-examples/bria_client.py)** — Full-featured async Python client


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the main **bria-ai** skill so assistants know where to find the complete, agent-oriented Bria API documentation when they are stuck on request shapes, parameters, or endpoints.

## Changes

- Short note under the intro directing agents to [https://docs.bria.ai/llms.txt](https://docs.bria.ai/llms.txt) as the canonical LLM-ready reference.
- Expanded **API Reference** section to call out **llms.txt** as the full spec and escape hatch beyond the in-repo summary.
- Added **llms.txt** as the first item under **Additional Resources**.

## Rationale

The in-skill quick reference and `references/api-endpoints.md` do not cover every edge case. Pointing stuck agents at the official **llms.txt** reduces guesswork and aligns implementation with agent-ready docs.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://bria-talk.slack.com/archives/D098W339N94/p1774183964766259?thread_ts=1774183964.766259&cid=D098W339N94)

<div><a href="https://cursor.com/agents/bc-7fdebca9-6d96-59a9-8280-dca6854ca9c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fdebca9-6d96-59a9-8280-dca6854ca9c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

