### PR TITLE
Fix: use relative SKILL_DIR path for bria_client.sh sourcing

### DIFF
--- a/preambles/image-input-handling.md
+++ b/preambles/image-input-handling.md
@@ -6,8 +6,10 @@ Shared pattern for Bria skills that accept image parameters.
 
 Replace `IMAGE_PATH_OR_URL` with the image URL or local file path.
 
+Source the helper script at `references/code-examples/bria_client.sh` (resolve relative to this skill's directory).
+
 ```bash
-source ~/.agents/skills/bria-ai/references/code-examples/bria_client.sh
+source <SKILL_DIR>/references/code-examples/bria_client.sh
 RESULT_URL=$(bria_call <ENDPOINT> "IMAGE_PATH_OR_URL" [extra JSON fields...])
 echo "$RESULT_URL"
 ```
@@ -17,7 +19,7 @@ The helper auto-loads the API key from `~/.bria/credentials` and handles URL pas
 ## Examples
 
 ```bash
-source ~/.agents/skills/bria-ai/references/code-examples/bria_client.sh
+source <SKILL_DIR>/references/code-examples/bria_client.sh
 
 # Remove background
 RESULT_URL=$(bria_call /v2/image/edit/remove_background "/path/to/image.png")

--- a/skills/bria-ai/SKILL.md
+++ b/skills/bria-ai/SKILL.md
@@ -170,8 +170,10 @@ Interpret the output:
 
 Use `bria_call` for all API calls. It handles URL passthrough, local file base64 encoding, JSON construction, API call, and async polling in a single function call. The API key is auto-loaded from `~/.bria/credentials`.
 
+**First**, source the helper script at `references/code-examples/bria_client.sh` (resolve relative to this skill's directory).
+
 ```bash
-source ~/.agents/skills/bria-ai/references/code-examples/bria_client.sh
+source <SKILL_DIR>/references/code-examples/bria_client.sh
 
 # Generate (no image input — pass empty string)
 RESULT=$(bria_call /v2/image/generate "" '"prompt": "your description", "aspect_ratio": "16:9", "sync": true')


### PR DESCRIPTION
## Summary
- Replaced hardcoded `~/.agents/skills/bria-ai/...` path with a `<SKILL_DIR>` placeholder that the agent resolves from whichever directory it read `SKILL.md` from
- Added natural-language instructions telling the agent to resolve `references/code-examples/bria_client.sh` relative to the skill's own directory
- Fixes path mismatch in Claude Code environments where skills are mounted at `/mnt/skills/` instead of `~/.agents/`

## Test plan
- [x] Verify the skill works in Cursor (agent resolves `<SKILL_DIR>` to `~/.agents/skills/bria-ai`)
- [x] Verify the skill works in Claude Code (agent resolves `<SKILL_DIR>` to `/mnt/skills/organization/bria-ai` or `/mnt/skills/user/bria-ai`)
- [x] Confirm `bria_call` function loads correctly after sourcing


Made with [Cursor](https://cursor.com)