### PR TITLE
Register remove-background skill, bump to v1.3.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Official Bria AI skills — text-to-image generation, image editing, background removal and replacement, object removal, inpainting, outpainting, upscale, restyle, product photography and packshots, batch/bulk generation, VGL structured prompts, and image utilities. Commercially licensed, royalty-free, brand-safe AI image generation and editing API.",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "repository": "https://github.com/bria-ai/bria-skill",
     "license": "MIT",
     "keywords": ["image-generation", "ai-images", "bria", "fibo", "rmbg", "background-removal", "background-replacement", "image-editing", "vgl", "product-photography", "packshot", "lifestyle-shot", "visual-assets", "text-to-image", "photo-editing", "transparent-png", "upscale", "outpaint", "inpaint", "object-removal", "restyle", "e-commerce", "marketing", "marketing-visuals", "social-media", "thumbnail", "banner", "hero-image", "ad-creative", "photo-restoration", "style-transfer", "royalty-free", "commercial-license", "brand-safe", "batch-generation", "bulk-generation", "image-variations", "compositing", "image-api", "pipeline", "visual-content-creation", "generate-image", "create-image", "ai-art", "photo-retouching", "image-enhancement", "relight", "reseason", "sketch-to-photo", "colorize", "web-design", "content-creation", "cutout", "product-placement", "scene-generation"]
@@ -58,6 +58,25 @@
       "strict": false,
       "skills": [
         "./skills/image-utils"
+      ],
+      "author": {
+        "name": "Bria AI"
+      }
+    },
+    {
+      "name": "remove-background",
+      "description": "Remove backgrounds from images for transparent PNGs, cutouts, and masks. Segment foreground from background using Bria RMBG 2.0. Dedicated background removal skill — faster and simpler than broader image tools for background removal, transparent PNG creation, product cutouts, headshot background removal, and batch background processing.",
+      "source": "./skills/remove-background",
+      "strict": false,
+      "skills": [
+        "./skills/remove-background"
+      ],
+      "dependencies": [
+        {
+          "type": "env",
+          "name": "BRIA_API_KEY",
+          "description": "Bria AI API key (get one at https://platform.bria.ai/console/account/api-keys)"
+        }
       ],
       "author": {
         "name": "Bria AI"

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ build/
 *.egg-info/
 tests
 bria-ai-workspace
+remove-background-workspace

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -5,7 +5,7 @@ const path = require("path");
 const os = require("os");
 
 const PACKAGE_NAME = "bria-skills";
-const SKILLS = ["bria-ai", "vgl", "image-utils"];
+const SKILLS = ["bria-ai", "vgl", "image-utils", "remove-background"];
 
 // Where the skill files live relative to this script
 const packageRoot = path.resolve(__dirname, "..");
@@ -79,9 +79,10 @@ Usage:
   npx ${PACKAGE_NAME} --help       Show this help
 
 Skills included:
-  bria-ai       AI-powered image generation and editing (FIBO, RMBG-2.0)
-  vgl           Visual Generation Language structured prompts
-  image-utils   Classic image manipulation (resize, crop, composite)
+  bria-ai            AI-powered image generation and editing (FIBO, RMBG-2.0)
+  vgl                Visual Generation Language structured prompts
+  image-utils        Classic image manipulation (resize, crop, composite)
+  remove-background  Background removal for transparent PNGs and cutouts (RMBG-2.0)
 
 More info: https://github.com/bria-ai/bria-skills
 `);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bria-skills",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Official Bria AI skills for Claude Code - image generation, editing, background removal, VGL structured prompts, and image utilities",
   "bin": {
     "bria-skills": "bin/cli.js"

--- a/skills/bria-ai/SKILL.md
+++ b/skills/bria-ai/SKILL.md
@@ -4,7 +4,7 @@ description: AI image generation, editing, and background removal API via Bria.a
 license: MIT
 metadata:
   author: Bria AI
-  version: "1.3.0"
+  version: "1.3.1"
 ---
 
 # Bria — AI Image Generation, Editing & Background Removal

--- a/skills/image-utils/SKILL.md
+++ b/skills/image-utils/SKILL.md
@@ -4,7 +4,7 @@ description: Classic image manipulation with Python Pillow - resize, crop, compo
 license: MIT
 metadata:
   author: Bria AI
-  version: "1.3.0"
+  version: "1.3.1"
 ---
 
 # Image Utilities

--- a/skills/remove-background/SKILL.md
+++ b/skills/remove-background/SKILL.md
@@ -4,7 +4,7 @@ description: Remove backgrounds from images — background removal API for trans
 license: MIT
 metadata:
   author: Bria AI
-  version: "1.3.0"
+  version: "1.3.1"
 ---
 
 # Remove Background — Transparent PNGs & Cutouts with RMBG 2.0

--- a/skills/vgl/SKILL.md
+++ b/skills/vgl/SKILL.md
@@ -4,7 +4,7 @@ description: Maximum control over AI image generation — write structured VGL (
 license: MIT
 metadata:
   author: Bria AI
-  version: "1.3.0"
+  version: "1.3.1"
 ---
 
 # Bria VGL — Full Control Over Image Generation


### PR DESCRIPTION
## Summary
- **Register remove-background skill** in `bin/cli.js` SKILLS array and `.claude-plugin/marketplace.json` plugins — the skill files were added in v1.3.0 but never wired into the CLI or marketplace, so users couldn't discover or install it
- **Bump version to 1.3.1** across package.json, marketplace.json, and all SKILL.md files

## Test plan
- [ ] Run `node bin/cli.js` and verify `remove-background` appears in the installed skills list
- [ ] Run `node bin/cli.js --help` and verify `remove-background` appears in the help text
- [ ] Verify marketplace.json is valid JSON with the new plugin entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)