### PR TITLE
Enforce bria_call usage and prefer agent_api_token

### DIFF
--- a/preambles/auth-device-flow.md
+++ b/preambles/auth-device-flow.md
@@ -20,7 +20,8 @@ Before making any API call, you need a valid Bria access token.
 ```bash
 if [ -f ~/.bria/credentials ]; then
   BRIA_ACCESS_TOKEN=$(grep '^access_token=' "$HOME/.bria/credentials" | cut -d= -f2-)
-  BRIA_API_KEY=$(grep '^api_token=' "$HOME/.bria/credentials" | cut -d= -f2-)
+  BRIA_API_KEY=$(grep '^agent_api_token=' "$HOME/.bria/credentials" | cut -d= -f2-)
+  [ -z "$BRIA_API_KEY" ] && BRIA_API_KEY=$(grep '^api_token=' "$HOME/.bria/credentials" | cut -d= -f2-)
 fi
 if [ -z "$BRIA_ACCESS_TOKEN" ]; then
   echo "NO_CREDENTIALS"
@@ -102,8 +103,9 @@ if [ "$ACTIVE" = "false" ]; then
 fi
 BRIA_API_KEY=$(printf '%s' "$INTROSPECT" | sed -n 's/.*"api_token" *: *"\([^"]*\)".*/\1/p')
 if [ -n "$BRIA_API_KEY" ]; then
-  grep -v '^api_token=' "$HOME/.bria/credentials" > "$HOME/.bria/credentials.tmp" 2>/dev/null || true
+  grep -vE '^(api_token|agent_api_token)=' "$HOME/.bria/credentials" > "$HOME/.bria/credentials.tmp" 2>/dev/null || true
   printf 'api_token=%s\n' "$BRIA_API_KEY" >> "$HOME/.bria/credentials.tmp"
+  printf 'agent_api_token=%s\n' "$BRIA_API_KEY" >> "$HOME/.bria/credentials.tmp"
   mv "$HOME/.bria/credentials.tmp" "$HOME/.bria/credentials"
 fi
 ```
@@ -112,3 +114,5 @@ Interpret the output:
 - If it prints `BILLING_ERROR: ...` — relay the message to the user exactly as shown and **stop**. Do not make any API calls.
 - If it prints `TOKEN_EXPIRED` — the session is no longer valid. Tell the user their session expired and restart from Step 2.
 - Otherwise, `BRIA_API_KEY` now contains the real API key and is cached for future calls. Proceed to the tool section.
+
+> **Important:** Always use `bria_call` (from `bria_client.sh`) for all Bria API requests — never `curl` endpoints directly. This ensures the correct `User-Agent` header and auth token are applied on every call.

--- a/preambles/auth-device-flow.md
+++ b/preambles/auth-device-flow.md
@@ -44,7 +44,8 @@ Start the device authorization flow:
 
 ```bash
 DEVICE_RESPONSE=$(curl -s -X POST "https://engine.prod.bria-api.com/v2/auth/device/authorize" \
-  -H "Content-Type: application/json")
+  -H "Content-Type: application/json" \
+  -d '{"client_type": "agent"}')
 echo "$DEVICE_RESPONSE"
 ```
 

--- a/skills/bria-ai/SKILL.md
+++ b/skills/bria-ai/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 Commercially safe, royalty-free image generation and editing through 20+ API endpoints. Generate from text, edit with natural language, remove backgrounds, create product shots, and build automated image pipelines.
 
-For additional endpoint details beyond what is documented here, see the [Bria API reference for agents](https://docs.bria.ai/llms.txt).
+If you are stuck on request shapes, parameters, or endpoints not covered here, **consult the full agent-oriented API reference** at [docs.bria.ai/llms.txt](https://docs.bria.ai/llms.txt) for endpoint schemas, parameters, and code examples. **However, never `curl` endpoints directly** — always use `bria_call` (see below) so the `User-Agent` header and auth token are applied correctly.
 
 ## When to Use This Skill
 
@@ -48,7 +48,8 @@ Before making any API call, you need a valid Bria access token.
 ```bash
 if [ -f ~/.bria/credentials ]; then
   BRIA_ACCESS_TOKEN=$(grep '^access_token=' "$HOME/.bria/credentials" | cut -d= -f2-)
-  BRIA_API_KEY=$(grep '^api_token=' "$HOME/.bria/credentials" | cut -d= -f2-)
+  BRIA_API_KEY=$(grep '^agent_api_token=' "$HOME/.bria/credentials" | cut -d= -f2-)
+  [ -z "$BRIA_API_KEY" ] && BRIA_API_KEY=$(grep '^api_token=' "$HOME/.bria/credentials" | cut -d= -f2-)
 fi
 if [ -z "$BRIA_ACCESS_TOKEN" ]; then
   echo "NO_CREDENTIALS"
@@ -131,8 +132,9 @@ if [ "$ACTIVE" = "false" ]; then
 fi
 BRIA_API_KEY=$(printf '%s' "$INTROSPECT" | sed -n 's/.*"api_token" *: *"\([^"]*\)".*/\1/p')
 if [ -n "$BRIA_API_KEY" ]; then
-  grep -v '^api_token=' "$HOME/.bria/credentials" > "$HOME/.bria/credentials.tmp" 2>/dev/null || true
+  grep -vE '^(api_token|agent_api_token)=' "$HOME/.bria/credentials" > "$HOME/.bria/credentials.tmp" 2>/dev/null || true
   printf 'api_token=%s\n' "$BRIA_API_KEY" >> "$HOME/.bria/credentials.tmp"
+  printf 'agent_api_token=%s\n' "$BRIA_API_KEY" >> "$HOME/.bria/credentials.tmp"
   mv "$HOME/.bria/credentials.tmp" "$HOME/.bria/credentials"
 fi
 ```

--- a/skills/bria-ai/SKILL.md
+++ b/skills/bria-ai/SKILL.md
@@ -72,7 +72,8 @@ Start the device authorization flow:
 
 ```bash
 DEVICE_RESPONSE=$(curl -s -X POST "https://engine.prod.bria-api.com/v2/auth/device/authorize" \
-  -H "Content-Type: application/json")
+  -H "Content-Type: application/json" \
+  -d '{"client_type": "agent"}')
 echo "$DEVICE_RESPONSE"
 ```
 

--- a/skills/bria-ai/references/code-examples/bria_client.sh
+++ b/skills/bria-ai/references/code-examples/bria_client.sh
@@ -27,7 +27,8 @@ bria_call() {
   done
 
   if [ -z "$BRIA_API_KEY" ] && [ -f "$HOME/.bria/credentials" ]; then
-    BRIA_API_KEY=$(grep '^api_token=' "$HOME/.bria/credentials" | cut -d= -f2-)
+    BRIA_API_KEY=$(grep '^agent_api_token=' "$HOME/.bria/credentials" | cut -d= -f2-)
+    [ -z "$BRIA_API_KEY" ] && BRIA_API_KEY=$(grep '^api_token=' "$HOME/.bria/credentials" | cut -d= -f2-)
   fi
   [ -z "$BRIA_API_KEY" ] && { echo "ERROR: BRIA_API_KEY not set. Run auth first." >&2; return 1; }
 


### PR DESCRIPTION
## Summary
- **SKILL.md**: Reframes `llms.txt` reference to mandate `bria_call` for all API calls (ensures `User-Agent: BriaSkills` header is always applied)
- **SKILL.md**: Credential loading now prefers `agent_api_token` over `api_token`
- **SKILL.md**: Token introspection saves both `api_token` and `agent_api_token` to credentials
- **bria_client.sh**: Reads `agent_api_token` first, falls back to `api_token`
- **auth-device-flow.md**: Same token loading/saving changes + mandate note for `bria_call`

## Context
Agents were sometimes `curl`-ing Bria endpoints directly (bypassing `bria_call`), which omitted the `User-Agent` header and caused agentic calls to go uncounted in dashboards. This PR:
1. Enforces `bria_call` usage so `User-Agent` is always present
2. Introduces `agent_api_token` preference so agent traffic uses a dedicated key type

Depends on [bria-internal](https://github.com/Bria-AI/bria-internal/pulls) and [spring](https://github.com/Bria-AI/spring/pulls) PRs for the backend AGENT key type.

## Test plan
- [ ] Fresh agent auth → credentials file contains both `api_token` and `agent_api_token`
- [ ] `bria_call` reads `agent_api_token` when present
- [ ] `bria_call` falls back to `api_token` when `agent_api_token` is missing
- [ ] Verify `User-Agent: BriaSkills` header is sent on every `bria_call`


Made with [Cursor](https://cursor.com)