### PR TITLE
fix(bria-ai): increase_resolution params — scale → desired_increase, document preserve_alpha

### DIFF
--- a/skills/bria-ai/SKILL.md
+++ b/skills/bria-ai/SKILL.md
@@ -188,8 +188,8 @@ RESULT=$(bria_call /v2/image/edit/replace_background "https://example.com/img.jp
 # Edit image (uses images array — pass --key images)
 RESULT=$(bria_call /v2/image/edit "/path/to/image.png" --key images '"instruction": "make it look warmer"')
 
-# Upscale
-RESULT=$(bria_call /v2/image/edit/increase_resolution "https://example.com/img.jpg" '"scale": 4')
+# Upscale (use `desired_increase`, range 2-4. Add `"preserve_alpha": true` for transparent inputs)
+RESULT=$(bria_call /v2/image/edit/increase_resolution "https://example.com/img.jpg" '"desired_increase": 4')
 
 # Lifestyle shot
 RESULT=$(bria_call /v1/product/lifestyle_shot_by_text "/path/to/product.png" '"prompt": "modern kitchen countertop"')

--- a/skills/bria-ai/references/api-endpoints.md
+++ b/skills/bria-ai/references/api-endpoints.md
@@ -255,7 +255,8 @@ Upscale image resolution.
 ```json
 {
   "image": "https://source-image-url",
-  "scale": 2
+  "desired_increase": 4,
+  "preserve_alpha": true
 }
 ```
 
@@ -264,7 +265,8 @@ Upscale image resolution.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `image` | string | required | Source image URL |
-| `scale` | int | 2 | Upscale factor (2 or 4) |
+| `desired_increase` | int | 2 | Upscale factor, range 2–4 |
+| `preserve_alpha` | bool | false | Preserve transparency. Set `true` when input has an alpha channel — the API upscales and recombines the alpha server-side, so you don't need to handle it client-side. |
 
 ### POST /v1/product/lifestyle_shot_by_text
 


### PR DESCRIPTION
## Summary
- The skill documented `scale` (2 or 4) as the upscale parameter for `/v2/image/edit/increase_resolution`, but the API silently ignores it and falls back to default 2x. Calls "succeeded" with valid PNGs at the wrong dimensions, masking the bug.
- Replaced with the actual parameter `desired_increase` (range 2–4).
- Documented the `preserve_alpha` flag so callers don't need to upscale and recombine the alpha channel client-side.

## Verification
Verified live against the API with the same 400×500 source image:
| Param | Result size | Behavior |
|---|---|---|
| `scale=4` | 800×1000 | param ignored, default 2x |
| `desired_increase=4` | 1600×2000 | correct 4x upscale |
| `preserve_alpha=true` (RGBA input) | RGBA preserved | works as documented |

## Files changed
- `skills/bria-ai/references/api-endpoints.md` — request example + parameters table
- `skills/bria-ai/SKILL.md` — Upscale code example

## Test plan
- [ ] Reviewer confirms `desired_increase` is the correct parameter name in the upstream Bria API spec (https://docs.bria.ai/llms.txt)
- [ ] Reviewer confirms `preserve_alpha` description matches API behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)