### PR TITLE
Release v1.3.2: fix increase_resolution params

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Official Bria AI skills — text-to-image generation, image editing, background removal and replacement, object removal, inpainting, outpainting, upscale, restyle, product photography and packshots, batch/bulk generation, VGL structured prompts, and image utilities. Commercially licensed, royalty-free, brand-safe AI image generation and editing API.",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "repository": "https://github.com/bria-ai/bria-skill",
     "license": "MIT",
     "keywords": ["image-generation", "ai-images", "bria", "fibo", "rmbg", "background-removal", "background-replacement", "image-editing", "vgl", "product-photography", "packshot", "lifestyle-shot", "visual-assets", "text-to-image", "photo-editing", "transparent-png", "upscale", "outpaint", "inpaint", "object-removal", "restyle", "e-commerce", "marketing", "marketing-visuals", "social-media", "thumbnail", "banner", "hero-image", "ad-creative", "photo-restoration", "style-transfer", "royalty-free", "commercial-license", "brand-safe", "batch-generation", "bulk-generation", "image-variations", "compositing", "image-api", "pipeline", "visual-content-creation", "generate-image", "create-image", "ai-art", "photo-retouching", "image-enhancement", "relight", "reseason", "sketch-to-photo", "colorize", "web-design", "content-creation", "cutout", "product-placement", "scene-generation"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bria-skills",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Official Bria AI skills for Claude Code - image generation, editing, background removal, VGL structured prompts, and image utilities",
   "bin": {
     "bria-skills": "bin/cli.js"

--- a/skills/bria-ai/SKILL.md
+++ b/skills/bria-ai/SKILL.md
@@ -4,7 +4,7 @@ description: AI image generation, editing, and background removal API via Bria.a
 license: MIT
 metadata:
   author: Bria AI
-  version: "1.3.1"
+  version: "1.3.2"
 ---
 
 # Bria — AI Image Generation, Editing & Background Removal

--- a/skills/bria-ai/SKILL.md
+++ b/skills/bria-ai/SKILL.md
@@ -188,8 +188,8 @@ RESULT=$(bria_call /v2/image/edit/replace_background "https://example.com/img.jp
 # Edit image (uses images array — pass --key images)
 RESULT=$(bria_call /v2/image/edit "/path/to/image.png" --key images '"instruction": "make it look warmer"')
 
-# Upscale
-RESULT=$(bria_call /v2/image/edit/increase_resolution "https://example.com/img.jpg" '"scale": 4')
+# Upscale (use `desired_increase`, range 2-4. Add `"preserve_alpha": true` for transparent inputs)
+RESULT=$(bria_call /v2/image/edit/increase_resolution "https://example.com/img.jpg" '"desired_increase": 4')
 
 # Lifestyle shot
 RESULT=$(bria_call /v1/product/lifestyle_shot_by_text "/path/to/product.png" '"prompt": "modern kitchen countertop"')

--- a/skills/bria-ai/references/api-endpoints.md
+++ b/skills/bria-ai/references/api-endpoints.md
@@ -255,7 +255,8 @@ Upscale image resolution.
 ```json
 {
   "image": "https://source-image-url",
-  "scale": 2
+  "desired_increase": 4,
+  "preserve_alpha": true
 }
 ```
 
@@ -264,7 +265,8 @@ Upscale image resolution.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `image` | string | required | Source image URL |
-| `scale` | int | 2 | Upscale factor (2 or 4) |
+| `desired_increase` | int | 2 | Upscale factor, range 2–4 |
+| `preserve_alpha` | bool | false | Preserve transparency. Set `true` when input has an alpha channel — the API upscales and recombines the alpha server-side, so you don't need to handle it client-side. |
 
 ### POST /v1/product/lifestyle_shot_by_text
 


### PR DESCRIPTION
## Summary
Release v1.3.2.

- **Fix `increase_resolution` parameters** (PR #43): replace the documented-but-ignored `scale` parameter with the actual API parameter `desired_increase` (range 2–4); document the `preserve_alpha` flag.
- **Bump version** to `1.3.2` across `package.json`, `.claude-plugin/marketplace.json`, and `skills/bria-ai/SKILL.md`.

## Why this matters
The skill previously documented `scale` (2 or 4) for upscaling, but the API silently ignores it and falls back to default 2x. Calls "succeeded" with valid PNGs at the wrong dimensions, masking the bug. Verified live: with `desired_increase=4` a 400×500 input correctly returns 1600×2000; with the old `scale=4` it returned only 800×1000.

## Commits
- `092c98c` chore: bump version to 1.3.2
- `b1919d9` Merge pull request #43 from Bria-AI/fix/increase-resolution-dev
- `12a0cdf` fix: increase_resolution params — scale → desired_increase, document preserve_alpha
- `3152866` Merge main into dev

## Test plan
- [ ] Skill validation passes (pre-commit hook already green on dev)
- [ ] Live API smoke-test of `/v2/image/edit/increase_resolution` with `desired_increase=2` and `=4` against both URL and local-file inputs (already verified before merge)
- [ ] Versions consistent across `package.json`, `marketplace.json`, and `skills/bria-ai/SKILL.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)