### PR TITLE
fix: rename lifestyle_shot_by_text param prompt → scene_description

### DIFF
--- a/kiro/bria-ai/POWER.md
+++ b/kiro/bria-ai/POWER.md
@@ -191,7 +191,7 @@ RESULT=$(bria_call /v2/image/edit "/path/to/image.png" --key images '"instructio
 RESULT=$(bria_call /v2/image/edit/increase_resolution "https://example.com/img.jpg" '"scale": 4')
 
 # Lifestyle shot
-RESULT=$(bria_call /v1/product/lifestyle_shot_by_text "/path/to/product.png" '"prompt": "modern kitchen countertop"')
+RESULT=$(bria_call /v1/product/lifestyle_shot_by_text "/path/to/product.png" '"scene_description": "modern kitchen countertop"')
 
 # Generate with tailored model (no image input — pass empty string)
 RESULT=$(bria_call /image/generate/tailored "" '"prompt": "product photo in brand style", "model_id": "your_model_id", "sync": true')

--- a/skills/bria-ai/SKILL.md
+++ b/skills/bria-ai/SKILL.md
@@ -192,7 +192,7 @@ RESULT=$(bria_call /v2/image/edit "/path/to/image.png" --key images '"instructio
 RESULT=$(bria_call /v2/image/edit/increase_resolution "https://example.com/img.jpg" '"desired_increase": 4')
 
 # Lifestyle shot
-RESULT=$(bria_call /v1/product/lifestyle_shot_by_text "/path/to/product.png" '"prompt": "modern kitchen countertop"')
+RESULT=$(bria_call /v1/product/lifestyle_shot_by_text "/path/to/product.png" '"scene_description": "modern kitchen countertop"')
 
 echo "$RESULT"
 ```


### PR DESCRIPTION
## Summary
The `/v1/product/lifestyle_shot_by_text` examples in the skill docs used `prompt`, but the API expects `scene_description` (as already documented in `skills/bria-ai/references/api-endpoints.md`). This aligns the examples with the API.

## Changes
- `skills/bria-ai/SKILL.md` — `prompt` → `scene_description`
- `kiro/bria-ai/POWER.md` — `prompt` → `scene_description`

🤖 Generated with [Claude Code](https://claude.com/claude-code)