### PR TITLE
chore: release 1.3.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Official Bria AI skills — text-to-image generation, image editing, background removal and replacement, object removal, inpainting, outpainting, upscale, restyle, product photography and packshots, batch/bulk generation, VGL structured prompts, and image utilities. Commercially licensed, royalty-free, brand-safe AI image generation and editing API.",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "repository": "https://github.com/bria-ai/bria-skill",
     "license": "MIT",
     "keywords": ["image-generation", "ai-images", "bria", "fibo", "rmbg", "background-removal", "background-replacement", "image-editing", "vgl", "product-photography", "packshot", "lifestyle-shot", "visual-assets", "text-to-image", "photo-editing", "transparent-png", "upscale", "outpaint", "inpaint", "object-removal", "restyle", "e-commerce", "marketing", "marketing-visuals", "social-media", "thumbnail", "banner", "hero-image", "ad-creative", "photo-restoration", "style-transfer", "royalty-free", "commercial-license", "brand-safe", "batch-generation", "bulk-generation", "image-variations", "compositing", "image-api", "pipeline", "visual-content-creation", "generate-image", "create-image", "ai-art", "photo-retouching", "image-enhancement", "relight", "reseason", "sketch-to-photo", "colorize", "web-design", "content-creation", "cutout", "product-placement", "scene-generation"]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ Generate, edit, and precisely control images directly from your AI coding agent 
 
 ### 1. Install
 
+**Claude Code (plugin):** add the marketplace, then install the plugin:
+
+```
+/plugin marketplace add Bria-AI/bria-skill
+/plugin install bria-ai@bria-skills
+```
+
+The marketplace also bundles the `remove-background`, `vgl`, and `image-utils` plugins — install any of them the same way (e.g. `/plugin install remove-background@bria-skills`).
+
+**Other agents** (Cursor, Cline, Codex, and [37+ more](https://skills.sh)):
+
 ```bash
 npx skills add bria-ai/bria-skill
 ```

--- a/kiro/bria-ai/POWER.md
+++ b/kiro/bria-ai/POWER.md
@@ -191,7 +191,7 @@ RESULT=$(bria_call /v2/image/edit "/path/to/image.png" --key images '"instructio
 RESULT=$(bria_call /v2/image/edit/increase_resolution "https://example.com/img.jpg" '"scale": 4')
 
 # Lifestyle shot
-RESULT=$(bria_call /v1/product/lifestyle_shot_by_text "/path/to/product.png" '"prompt": "modern kitchen countertop"')
+RESULT=$(bria_call /v1/product/lifestyle_shot_by_text "/path/to/product.png" '"scene_description": "modern kitchen countertop"')
 
 # Generate with tailored model (no image input — pass empty string)
 RESULT=$(bria_call /image/generate/tailored "" '"prompt": "product photo in brand style", "model_id": "your_model_id", "sync": true')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bria-skills",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Official Bria AI skills for Claude Code - image generation, editing, background removal, VGL structured prompts, and image utilities",
   "bin": {
     "bria-skills": "bin/cli.js"

--- a/skills/bria-ai/SKILL.md
+++ b/skills/bria-ai/SKILL.md
@@ -4,7 +4,7 @@ description: AI image generation, editing, and background removal API via Bria.a
 license: MIT
 metadata:
   author: Bria AI
-  version: "1.3.2"
+  version: "1.3.3"
 ---
 
 # Bria — AI Image Generation, Editing & Background Removal

--- a/skills/bria-ai/SKILL.md
+++ b/skills/bria-ai/SKILL.md
@@ -192,7 +192,7 @@ RESULT=$(bria_call /v2/image/edit "/path/to/image.png" --key images '"instructio
 RESULT=$(bria_call /v2/image/edit/increase_resolution "https://example.com/img.jpg" '"desired_increase": 4')
 
 # Lifestyle shot
-RESULT=$(bria_call /v1/product/lifestyle_shot_by_text "/path/to/product.png" '"prompt": "modern kitchen countertop"')
+RESULT=$(bria_call /v1/product/lifestyle_shot_by_text "/path/to/product.png" '"scene_description": "modern kitchen countertop"')
 
 echo "$RESULT"
 ```


### PR DESCRIPTION
## Summary
Release 1.3.3.

## Changes
- Bump version `1.3.2` → `1.3.3` (`package.json`, `.claude-plugin/marketplace.json`, `skills/bria-ai/SKILL.md`)
- Includes the merged fix: `lifestyle_shot_by_text` parameter `prompt` → `scene_description` (#45)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version metadata only; no runtime or API client code changes.
> 
> **Overview**
> **Release 1.3.3** bumps the package, Claude marketplace, and skill metadata from `1.3.2` to `1.3.3`.
> 
> The **README** now documents **Claude Code** setup via marketplace/plugin commands (`/plugin marketplace add`, `/plugin install`) and notes bundled plugins (`remove-background`, `vgl`, `image-utils`), while keeping the `npx skills add` path for other agents.
> 
> Skill docs align **`/v1/product/lifestyle_shot_by_text`** examples with the API: the JSON field is **`scene_description`** instead of **`prompt`** in `skills/bria-ai/SKILL.md` and `kiro/bria-ai/POWER.md`. The main skill example also documents upscale via **`desired_increase`** (replacing **`scale`**) for `increase_resolution`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c78ae6bd7ac8007e042975c109bb73f1c6bdb94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->