### PR TITLE
ci: publish release assets with .skill suffix

### DIFF
--- a/.github/workflows/release-skills.yml
+++ b/.github/workflows/release-skills.yml
@@ -26,7 +26,7 @@ jobs:
               skill_name=$(basename "$dir")
               echo "Zipping skill: $skill_name"
               cd skills
-              zip -r "../release-assets/${skill_name}.zip" "$skill_name" \
+              zip -r "../release-assets/${skill_name}.skill" "$skill_name" \
                 -x "*/.DS_Store" "*/__pycache__/*" "*.pyc" "*/.DS_Store"
               cd ..
               skills="${skills}${skill_name}, "
@@ -48,4 +48,4 @@ jobs:
           name: ${{ steps.version.outputs.tag }}
           generate_release_notes: true
           make_latest: true
-          files: release-assets/*.zip
+          files: release-assets/*.skill


### PR DESCRIPTION
Renames the release assets produced by the **Release Skills** workflow from `<skill>.zip` to `<skill>.skill`.

Only the suffix changes — the archives are still zip containers built by the same `zip -r` invocation. `zip` appends `.zip` only when the target name has no extension, so `<skill>.skill` is written as-is.

- `zip -r "../release-assets/${skill_name}.skill" …`
- `files: release-assets/*.skill` for the `softprops/action-gh-release` upload

`.zip` appeared nowhere else in the repo (nothing in `bin/`, `README.md`, or the plugin manifest references the asset names), and `publish-npm.yml` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skill release artifacts are now published using the `.skill` file format.
  * Skill artifacts are attached directly to GitHub releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->