### PR TITLE
ci: allow Release Skills to be run on demand

### DIFF
--- a/.github/workflows/release-skills.yml
+++ b/.github/workflows/release-skills.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'skills/**'
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger to **Release Skills** so it can be run on demand.

The `push` trigger is filtered to `paths: ['skills/**']`, so workflow-only changes (like #52, which renamed the release assets to `.skill`) never exercise the workflow. This makes a manual run possible.

Heads-up on the first manual run at the current version: `package.json` is `1.3.5` and tag `v1.3.5` already exists carrying the six `.zip` assets. A dispatch now will attach the six `.skill` assets *alongside* those, and the cascading `Publish to npm` job will fail because 1.3.5 is already published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
