### PR TITLE
feat: Multi-reference image editing across the skill variants (BLD-179)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Official Bria AI skills — text-to-image generation, image editing, background removal and replacement, object removal, inpainting, outpainting, upscale, restyle, product photography and packshots, batch/bulk generation, VGL structured prompts, and image utilities. Commercially licensed, royalty-free, brand-safe AI image generation and editing API.",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "repository": "https://github.com/bria-ai/bria-skill",
     "license": "MIT",
     "keywords": ["image-generation", "ai-images", "bria", "fibo", "rmbg", "background-removal", "background-replacement", "image-editing", "vgl", "product-photography", "packshot", "lifestyle-shot", "visual-assets", "text-to-image", "photo-editing", "transparent-png", "upscale", "outpaint", "inpaint", "object-removal", "restyle", "e-commerce", "marketing", "marketing-visuals", "social-media", "thumbnail", "banner", "hero-image", "ad-creative", "photo-restoration", "style-transfer", "royalty-free", "commercial-license", "brand-safe", "batch-generation", "bulk-generation", "image-variations", "compositing", "image-api", "pipeline", "visual-content-creation", "generate-image", "create-image", "ai-art", "photo-retouching", "image-enhancement", "relight", "reseason", "sketch-to-photo", "colorize", "web-design", "content-creation", "cutout", "product-placement", "scene-generation"]

--- a/bria-ai-openclaw/openclaw.plugin.json
+++ b/bria-ai-openclaw/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "bria",
   "name": "Bria AI Skills",
   "description": "Commercially-safe AI image & video toolkit for OpenClaw, powered by Bria.ai. Bundles six skills: bria-ai (text-to-image, instruction editing, background replace, product photography, upscale, restyle — 20+ endpoints), video-remove-background (transparent / alpha-channel video matting), remove-background (RMBG-2.0 transparent PNGs), vgl (structured VGL JSON for deterministic generation), image-utils (Pillow resize/crop/composite/watermark), and automotive (vehicle imagery). Royalty-free, brand-safe, production-ready.",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "icon": "https://bria.ai/favicon.ico",
   "skills": [
     "./skills/bria-ai",

--- a/bria-ai-openclaw/package.json
+++ b/bria-ai-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galbria/bria-ai-openclaw",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Official Bria AI plugin for OpenClaw — commercially-safe AI image & video toolkit. Bundles six skills: bria-ai, video-remove-background, remove-background, vgl, image-utils, and automotive.",
   "type": "module",
   "license": "MIT",

--- a/bria-ai-openclaw/skills/automotive/SKILL.md
+++ b/bria-ai-openclaw/skills/automotive/SKILL.md
@@ -4,7 +4,7 @@ description: Vehicle/automotive image editing for cars, trucks, SUVs, motorcycle
 license: MIT
 metadata:
   author: Bria AI
-  version: "1.3.5"
+  version: "1.3.6"
 ---
 
 # Bria Automotive — Vehicle Image Editing & Shot Generation

--- a/bria-ai-openclaw/skills/automotive/references/code-examples/bria_client.sh
+++ b/bria-ai-openclaw/skills/automotive/references/code-examples/bria_client.sh
@@ -12,7 +12,7 @@
 # BRIA_API_KEY is auto-loaded from ~/.bria/credentials if not already set.
 
 BRIA_API_BASE="${BRIA_API_BASE:-https://engine.prod.bria-api.com}"
-BRIA_USER_AGENT="BriaSkills/1.3.5"
+BRIA_USER_AGENT="BriaSkills/1.3.6"
 
 bria_call() {
   local endpoint image key extra payload result http_code body url status_url poll i

--- a/bria-ai-openclaw/skills/bria-ai/SKILL.md
+++ b/bria-ai-openclaw/skills/bria-ai/SKILL.md
@@ -12,7 +12,7 @@ license: MIT
 homepage: https://bria.ai
 metadata:
   author: Bria AI
-  version: "1.3.5"
+  version: "1.3.6"
   openclaw:
     requires:
       env:
@@ -111,6 +111,9 @@ Generate image from scratch (text → image)?
 Edit existing image with text instruction?
   → /v2/image/edit  (use --key images)
 
+Combine 2-4 images — outfit, product, logo, style, or background from one into another?
+  → /v2/image/edit  (--key images, then one --image per extra reference)
+
 Change / replace / blur background?
   → /v2/image/edit/replace_background  (prompt: "blur" or describe new bg)
 
@@ -143,6 +146,11 @@ RESULT=$(bria_call /v2/image/edit/replace_background "https://example.com/img.jp
 # Edit image (uses images array — pass --key images)
 RESULT=$(bria_call /v2/image/edit "/path/to/image.png" --key images '"instruction": "make it look warmer"')
 
+# Edit with reference images — each --image adds the next one, in order
+RESULT=$(bria_call /v2/image/edit "https://example.com/man.jpg" --key images \
+  --image "https://example.com/santa.png" \
+  '"instruction": "dress the man in image 1 in the santa outfit from image 2"')
+
 # Upscale
 RESULT=$(bria_call /v2/image/edit/increase_resolution "https://example.com/img.jpg" '"scale": 4')
 
@@ -155,7 +163,13 @@ echo "$RESULT"
 **Calling convention:** `bria_call <endpoint> <image_or_empty> [--key <json_key>] [extra JSON fields...]`
 - Pass a URL, local file path, or `""` for endpoints without image input
 - Use `--key images` when the endpoint expects an `images` array instead of `image`
+- Add `--image <url_or_path>` once per extra reference image (`--key images`, up to 4 in total).
+  Order is preserved: the positional image is "image 1", the first `--image` is "image 2", …
 - Returns the result image URL on success, or prints an error to stderr
+
+**Editing with several images (2-4):** put the image being edited first, references after it, and
+address them by position — *"dress the man in image 1 in the santa outfit from image 2"*. Say what
+each reference contributes, in plain prose. Single-image edits need no positional wording.
 
 **Generation options:** Aspect ratios `1:1`, `16:9`, `4:3`, `9:16`, `3:4`. Resolution `1MP` (default) or `4MP` (more detail, +30s). Pass `"sync": true` for single images.
 

--- a/bria-ai-openclaw/skills/bria-ai/SKILL.md
+++ b/bria-ai-openclaw/skills/bria-ai/SKILL.md
@@ -171,7 +171,9 @@ echo "$RESULT"
 address them by position — *"dress the man in image 1 in the santa outfit from image 2"*. Say what
 each reference contributes, in plain prose. Single-image edits need no positional wording.
 
-**Generation options:** Aspect ratios `1:1`, `16:9`, `4:3`, `9:16`, `3:4`. Resolution `1MP` (default) or `4MP` (more detail, +30s). Pass `"sync": true` for single images.
+**Generation options:** Aspect ratios `1:1`, `16:9`, `4:3`, `9:16`, `3:4`. Resolution `1MP` (default) or `4MP` (more detail, +30s). Pass `"sync": true` for a single generated image. Editing endpoints are the other way round —
+they answer with a `status_url` you poll, and `"sync": true` on an edit fails with a gateway
+timeout.
 
 > **Advanced**: For precise control over generation, use the **vgl** skill for structured VGL JSON prompts.
 

--- a/bria-ai-openclaw/skills/bria-ai/SKILL.md
+++ b/bria-ai-openclaw/skills/bria-ai/SKILL.md
@@ -152,7 +152,7 @@ RESULT=$(bria_call /v2/image/edit "https://example.com/man.jpg" --key images \
   '"instruction": "dress the man in image 1 in the santa outfit from image 2"')
 
 # Upscale
-RESULT=$(bria_call /v2/image/edit/increase_resolution "https://example.com/img.jpg" '"scale": 4')
+RESULT=$(bria_call /v2/image/edit/increase_resolution "https://example.com/img.jpg" '"desired_increase": 4')
 
 # Lifestyle shot
 RESULT=$(bria_call /v1/product/lifestyle_shot_by_text "/path/to/product.png" '"scene_description": "modern kitchen countertop"')

--- a/bria-ai-openclaw/skills/bria-ai/references/api-endpoints.md
+++ b/bria-ai-openclaw/skills/bria-ai/references/api-endpoints.md
@@ -157,8 +157,12 @@ position — the first is "image 1", the second "image 2", and so on:
   just that it exists.
 - Plain prose, plain words — "image 1", "image 2". No brackets, tags, or markup.
 
+This endpoint is asynchronous: it answers with `request_id` and `status_url`, which you poll. Do
+not send `"sync": true` here — an instruction edit takes longer than a single response is allowed to
+take, so a synchronous request fails with a gateway timeout even though the job itself is fine.
+
 **Constraints** — each returns 422 with a readable message:
-- More than 4 images.
+- More than 4 images. Trim the set before sending; the request is refused, not truncated.
 - A `mask` together with 2 or more images (masked edits are single-image only).
 - 2 or more images together with a tailored `model_id` or `model_version: FIBO_BBQ` — both of those
   run on the single-reference model.

--- a/bria-ai-openclaw/skills/bria-ai/references/api-endpoints.md
+++ b/bria-ai-openclaw/skills/bria-ai/references/api-endpoints.md
@@ -255,7 +255,8 @@ Upscale image resolution.
 ```json
 {
   "image": "https://source-image-url",
-  "scale": 2
+  "desired_increase": 4,
+  "preserve_alpha": true
 }
 ```
 
@@ -264,7 +265,43 @@ Upscale image resolution.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `image` | string | required | Source image URL |
-| `scale` | int | 2 | Upscale factor (2 or 4) |
+| `desired_increase` | int | 2 | Upscale factor, range 2–4 |
+| `preserve_alpha` | bool | false | Preserve transparency. Set `true` when input has an alpha channel — the API upscales and recombines the alpha server-side, so you don't need to handle it client-side. |
+
+### POST /v1/product/cutout
+
+Remove the background from a product photo → clean transparent PNG. The `/v1/product/*` endpoints take `image_url` (URL) or `file` (base64).
+
+**Request:**
+```json
+{ "image_url": "https://…/raw.jpg" }
+```
+Response: `{ "result_url": "https://…png" }` (synchronous).
+
+### POST /v1/product/packshot
+
+Standardized 2000×2000 packshot on a solid/clean background.
+
+| Parameter | Type | Notes |
+|-----------|------|-------|
+| `image_url` / `file` | string | Product image (a cutout is recommended) |
+| `background_color` | string | Hex like `#FFFFFF`, or `transparent` |
+| `sku` | string | Optional label/id |
+
+Response: `{ "result_url": "…" }` (synchronous).
+
+### POST /v1/product/shadow
+
+Add a realistic shadow to a product cutout.
+
+| Parameter | Type | Notes |
+|-----------|------|-------|
+| `image_url` / `file` | string | Product cutout |
+| `type` | string | `regular` (drop) or `float` (elliptical) |
+| `background_color` | string | Hex or `transparent` |
+| `shadow_intensity` | int | 0–100 (approx) |
+
+Response: `{ "result_url": "…" }` (synchronous).
 
 ### POST /v1/product/lifestyle_shot_by_text
 
@@ -274,10 +311,38 @@ Place a product in a lifestyle scene using text description.
 ```json
 {
   "file": "BASE64_ENCODED_IMAGE",
-  "prompt": "modern kitchen countertop, natural lighting",
+  "scene_description": "modern kitchen countertop, natural lighting",
   "placement_type": "automatic"
 }
 ```
+
+**Parameters:**
+
+| Parameter | Type | Notes |
+|-----------|------|-------|
+| `image_url` / `file` | string | Product (cutout recommended) |
+| `scene_description` | string | Environment + lighting + mood |
+| `mode` | string | `base`, `high_control` (recommended), `fast` |
+| `placement_type` | string | `automatic`, `automatic_aspect_ratio`, `manual_placement`, `custom_coordinates`, `manual_padding`, `original` |
+| `aspect_ratio` | string | e.g. `1:1`, `4:5`, `16:9` (with `automatic_aspect_ratio`) |
+| `num_results` | int | Number of variations |
+| `sync` | bool | `true` returns results inline |
+| `optimize_description` | bool | Let Bria refine the prompt |
+
+Response: `{ "result": [[ "image_url", "seed", "session_id" ], …] }` — extract `result[0][0]`.
+
+### POST /v1/product/lifestyle_shot_by_image
+
+Same as `lifestyle_shot_by_text`, but the scene comes from a reference background image instead of a text description.
+
+| Parameter | Type | Notes |
+|-----------|------|-------|
+| `image_url` / `file` | string | Product |
+| `ref_image_urls` | array | One or more background reference URLs |
+| `placement_type` | string | see above |
+| `num_results` | int | variations |
+
+Response: `{ "result": [[ "image_url", … ], …] }`.
 
 ### POST /image/edit/product/integrate
 
@@ -333,6 +398,63 @@ Integrate and embed one or more products into a predefined scene at precise user
   "status_url": "https://..."
 }
 ```
+
+### POST /v2/image/edit/product_dimensions
+
+Render a marketplace-ready dimension image from a product photo: the background is removed automatically, then measurement callout lines + labels are drawn around the product, with an optional title and optional weight/capacity text. Three visual styles. Useful for e-commerce listings (Amazon-style "dimensions" images).
+
+**Request:**
+```json
+{
+  "image": "https://product-image-url",
+  "style": "default",
+  "dimensions": [
+    {"name": "height", "value": 12, "unit": "cm", "position": "left"},
+    {"name": "width_bottom", "value": 6, "unit": "cm", "position": "bottom"}
+  ],
+  "title": "Gummies Bottle",
+  "weight": {"value": 250, "unit": "g", "label": "Net Weight"},
+  "capacity": {"value": 500, "unit": "ml"},
+  "background": "white",
+  "output_format": "png"
+}
+```
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `image` | string | required | Product photo URL or base64. Background is removed automatically — no pre-cutout needed |
+| `dimensions` | array | required | One or more dimension callouts (min 1) |
+| `dimensions[].name` | string | required | `height`, `width_bottom`, or `width_top` (`length`/`depth` not currently enabled) |
+| `dimensions[].value` | float | required | Physical measurement value (must be > 0) |
+| `dimensions[].unit` | string | required | `mm`, `cm`, `m`, `in`, `"` (inches), `ft`, `'` (feet) |
+| `dimensions[].position` | string | per-name | Callout side: `top`, `bottom`, `left`, `right`. Defaults: height→`left`, width_bottom→`bottom`, width_top→`top` |
+| `style` | string | required | `default`, `childlike`, or `elegant` |
+| `units_display` | string | "single" | `single`, `dual_bullet`, `dual_slash`, `dual_parens`. For dual modes, supply two `dimensions` entries with the same `name`+`position` but different `unit` (e.g. `in` and `cm`) — they merge into one dual-unit label |
+| `background` | string | "white" | `white`, `cream`, `charcoal`, or a hex color (e.g. `#f5f0e8`) |
+| `title` | string | - | Optional headline above the product (max 80 chars) |
+| `title_position` | string | "top_center" | `top_left`, `top_center`, `top_right` |
+| `weight` | object | - | Optional weight callout below the product |
+| `weight.value` | float | required* | Weight value (> 0) *if `weight` is provided |
+| `weight.unit` | string | required* | `lb`, `oz`, `g`, `kg` |
+| `weight.label` | string | "Weight" | `Weight` or `Net Weight` |
+| `capacity` | object | - | Optional capacity callout below the product |
+| `capacity.value` | float | required* | Capacity value (> 0) *if `capacity` is provided |
+| `capacity.unit` | string | required* | `fl_oz`, `ml`, `l`, `qt`, `gal`, `cups` |
+| `output_format` | string | "png" | `png`, `jpeg`, or `dual` (composite PNG + a transparent overlay-only PNG, returned as two images) |
+| `output_size` | int | 2200 | Square output edge length in px (256–2200) |
+| `proportional_lines` | bool | true | Scale each dimension line's length to its measurement (the largest per axis spans the product) |
+
+**Async Response (202):**
+```json
+{
+  "request_id": "uuid",
+  "status_url": "https://..."
+}
+```
+
+Poll `status_url` for the result. `dual` output returns two images: `[composite, overlay]`.
 
 ---
 

--- a/bria-ai-openclaw/skills/bria-ai/references/api-endpoints.md
+++ b/bria-ai-openclaw/skills/bria-ai/references/api-endpoints.md
@@ -11,7 +11,7 @@ Content-Type: application/json
 User-Agent: BriaSkills/<version>
 ```
 
-> **Required:** Always include the `User-Agent: BriaSkills/<version>` header (where `<version>` is the current skill version from `package.json`, e.g. `BriaSkills/1.3.5`) in every API call, including status polling requests.
+> **Required:** Always include the `User-Agent: BriaSkills/<version>` header (where `<version>` is the current skill version from `package.json`, e.g. `BriaSkills/1.3.6`) in every API call, including status polling requests.
 
 ---
 
@@ -120,7 +120,9 @@ Remove background from image. Returns PNG with transparency.
 
 ### POST /v2/image/edit
 
-Edit an image using natural language instructions. No mask required.
+Edit an image with a natural language instruction — no mask required. Send one image to change it,
+or 2–4 images to combine them: the subject from one with an outfit, product, style, or background
+from another.
 
 **Request:**
 ```json
@@ -130,12 +132,53 @@ Edit an image using natural language instructions. No mask required.
 }
 ```
 
+**Multi-reference request.** `images` is ordered, and the instruction addresses each entry by its
+position — the first is "image 1", the second "image 2", and so on:
+```json
+{
+  "images": ["https://man-image-url", "https://santa-outfit-image-url"],
+  "instruction": "dress the man in image 1 in the santa outfit from image 2",
+  "seed": 1234
+}
+```
+
 **Parameters:**
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `images` | array | required | Array of image URLs or base64 data URLs |
-| `instruction` | string | required | Edit instruction in natural language |
+| `images` | array | required | 1–4 image URLs or base64 data URLs. **Order matters** — the instruction refers to them as "image 1", "image 2", … in the order they are sent |
+| `instruction` | string | required | Edit instruction in natural language. Refer to additional images by position |
+| `seed` | int | random | For reproducibility — the same images, instruction and seed reproduce the same result |
+| `aspect_ratio` | string | - | Output ratio: "1:1", "4:3", "16:9", "3:4", "9:16". Honored with 2+ images; with a single image the output follows that image and the response `warning` says so. Omit it to follow the first image |
+| `model_version` | string | - | Deprecated and ignored — the service picks the edit model from the request contents. A value that is sent comes back with a notice in `warning`; omit it |
+
+**Writing a multi-reference instruction:**
+- Put the image being edited first and the references after it.
+- Say what each reference contributes ("the outfit from image 2", "the background of image 3"), not
+  just that it exists.
+- Plain prose, plain words — "image 1", "image 2". No brackets, tags, or markup.
+
+**Constraints** — each returns 422 with a readable message:
+- More than 4 images.
+- A `mask` together with 2 or more images (masked edits are single-image only).
+- 2 or more images together with a tailored `model_id` or `model_version: FIBO_BBQ` — both of those
+  run on the single-reference model.
+
+**Completed Result:**
+```json
+{
+  "status": "COMPLETED",
+  "result": {
+    "image_url": "https://...",
+    "seed": 1234,
+    "warning": null
+  }
+}
+```
+
+`warning` is set when a parameter was accepted but not honored — `aspect_ratio` on a single-image
+request, a supplied `model_version`, or a tuning parameter the serving model does not read. Relay it
+to the user rather than dropping it.
 
 ### POST /v2/image/edit/gen_fill
 
@@ -664,7 +707,7 @@ Check async request status.
 import requests, time
 
 def poll(status_url, api_key, timeout=120):
-    headers = {"api_token": api_key, "User-Agent": "BriaSkills/1.3.5"}
+    headers = {"api_token": api_key, "User-Agent": "BriaSkills/1.3.6"}
     for _ in range(timeout // 2):
         r = requests.get(status_url, headers=headers)
         data = r.json()

--- a/bria-ai-openclaw/skills/bria-ai/references/api-endpoints.md
+++ b/bria-ai-openclaw/skills/bria-ai/references/api-endpoints.md
@@ -28,7 +28,6 @@ Generate images from text prompts using FIBO's structured prompt system.
   "aspect_ratio": "1:1",
   "resolution": "1MP",
   "negative_prompt": "string",
-  "num_results": 1,
   "seed": null
 }
 ```
@@ -38,22 +37,22 @@ Generate images from text prompts using FIBO's structured prompt system.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `prompt` | string | required* | Image description (* or use `structured_prompt`) |
-| `aspect_ratio` | string | "1:1" | "1:1", "4:3", "16:9", "3:4", "9:16" |
+| `aspect_ratio` | string | "1:1" | "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9" |
 | `resolution` | string | "1MP" | Output image resolution. "1MP" or "4MP". "4MP" improves image details, especially for photorealism, but increases latency by ~30 seconds. |
 | `negative_prompt` | string | - | What to exclude |
-| `num_results` | int | 1 | Number of images (1-4) |
 | `seed` | int | random | For reproducibility |
 | `structured_prompt` | string | - | JSON from previous generation (for refinement). Use with `prompt` to refine, or alone with `seed` to recreate. |
-| `image_url` | string | - | Reference image (for inspire mode) |
+| `images` | array | - | Reference image for inspire mode: an array holding one image URL or base64 string |
 
-**Input Combination Rules** (mutually exclusive):
+**Input Combinations** — at least one of `prompt`, `images` or `structured_prompt` is required:
 - `prompt` — Generate from text
-- `image_url` — Generate inspired by a reference image
-- `image_url` + `prompt` — Generate inspired by image, guided by text
+- `images` — Generate inspired by a reference image
+- `images` + `prompt` — Generate inspired by image, guided by text
 - `structured_prompt` + `seed` — Recreate a previous image exactly
 - `structured_prompt` + `prompt` + `seed` — Refine a previous image with new instructions
 
-All combinations support `aspect_ratio`, `negative_prompt`, `num_results`, and `seed`.
+All combinations support `aspect_ratio`, `negative_prompt` and `seed`. Note that `"sync": true`
+cannot be combined with `"resolution": "4MP"` — that pairing is rejected.
 
 **Response:**
 ```json
@@ -149,7 +148,7 @@ position — the first is "image 1", the second "image 2", and so on:
 | `images` | array | required | 1–4 image URLs or base64 data URLs. **Order matters** — the instruction refers to them as "image 1", "image 2", … in the order they are sent |
 | `instruction` | string | required | Edit instruction in natural language. Refer to additional images by position |
 | `seed` | int | random | For reproducibility — the same images, instruction and seed reproduce the same result |
-| `aspect_ratio` | string | - | Output ratio: "1:1", "4:3", "16:9", "3:4", "9:16". Honored with 2+ images; with a single image the output follows that image and the response `warning` says so. Omit it to follow the first image |
+| `aspect_ratio` | string | - | Output ratio: "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9". Honored with 2+ images; with a single image the output follows that image and the response `warning` says so. Omit it to follow the first image |
 | `model_version` | string | - | Deprecated and ignored — the service picks the edit model from the request contents. A value that is sent comes back with a notice in `warning`; omit it |
 
 **Writing a multi-reference instruction:**
@@ -171,10 +170,15 @@ position — the first is "image 1", the second "image 2", and so on:
   "result": {
     "image_url": "https://...",
     "seed": 1234,
+    "structured_prompt": "{...}",
     "warning": null
   }
 }
 ```
+
+The result also carries the structured instruction the edit was rendered from — named
+`structured_prompt` on a polled result and `structured_instruction` on an inline `"sync": true`
+response. Read whichever is present.
 
 `warning` is set when a parameter was accepted but not honored — `aspect_ratio` on a single-image
 request, a supplied `model_version`, or a tuning parameter the serving model does not read. Relay it
@@ -190,9 +194,7 @@ Generate content in a masked region (inpainting).
   "image": "https://source-image-url",
   "mask": "https://mask-image-url",
   "prompt": "what to generate",
-  "mask_type": "manual",
-  "negative_prompt": "string",
-  "num_results": 1
+  "mask_type": "manual"
 }
 ```
 
@@ -204,8 +206,6 @@ Generate content in a masked region (inpainting).
 | `mask` | string | required | Mask URL (white=edit, black=keep) |
 | `prompt` | string | required | What to generate in masked area |
 | `mask_type` | string | "manual" | "manual" or "automatic" |
-| `negative_prompt` | string | - | What to avoid |
-| `num_results` | int | 1 | Number of variations |
 
 **Mask Requirements:**
 - White pixels (255) = area to edit
@@ -276,7 +276,7 @@ Expand/outpaint an image to extend its boundaries.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `image` | string | required | Source image URL or base64 string |
-| `aspect_ratio` | string | required | Target ratio: "1:1", "4:3", "16:9", "3:4", "9:16" |
+| `aspect_ratio` | string \| float | - | Target ratio: "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", or a float. Omit it and pass `canvas_size` instead |
 | `prompt` | string | - | Optional - describe content to generate |
 
 ### POST /v2/image/edit/enhance
@@ -308,8 +308,8 @@ Upscale image resolution.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `image` | string | required | Source image URL |
-| `desired_increase` | int | 2 | Upscale factor, range 2–4 |
-| `preserve_alpha` | bool | false | Preserve transparency. Set `true` when input has an alpha channel — the API upscales and recombines the alpha server-side, so you don't need to handle it client-side. |
+| `desired_increase` | int | 2 | Upscale factor: 2 or 4 |
+| `preserve_alpha` | bool | true | Preserve transparency. Set `true` when input has an alpha channel — the API upscales and recombines the alpha server-side, so you don't need to handle it client-side. |
 
 ### POST /v1/product/cutout
 
@@ -387,7 +387,7 @@ Same as `lifestyle_shot_by_text`, but the scene comes from a reference backgroun
 
 Response: `{ "result": [[ "image_url", … ], …] }`.
 
-### POST /image/edit/product/integrate
+### POST /v2/image/edit/product/integrate
 
 Integrate and embed one or more products into a predefined scene at precise user-defined coordinates. The product is automatically matched to the scene's lighting, perspective, and aesthetics. Products are automatically cut out from their background as part of the pipeline.
 
@@ -442,9 +442,12 @@ Integrate and embed one or more products into a predefined scene at precise user
 }
 ```
 
-### POST /v2/image/edit/product_dimensions
+### POST /v2/image/edit/product/generate/dimensions
 
-Render a marketplace-ready dimension image from a product photo: the background is removed automatically, then measurement callout lines + labels are drawn around the product, with an optional title and optional weight/capacity text. Three visual styles. Useful for e-commerce listings (Amazon-style "dimensions" images).
+Render a marketplace-ready dimension image from a product photo. (The older
+`/v2/image/edit/product_dimensions` path still works but is deprecated — use this one.)
+
+How it works: the background is removed automatically, then measurement callout lines + labels are drawn around the product, with an optional title and optional weight/capacity text. Three visual styles. Useful for e-commerce listings (Amazon-style "dimensions" images).
 
 **Request:**
 ```json
@@ -551,8 +554,7 @@ Blend/merge images or apply textures.
 ```json
 {
   "image": "base64-or-url",
-  "overlay": "texture-or-art-url",
-  "instruction": "Place the art on the shirt, keep the art exactly the same"
+  "instruction": "Place the art from this image on the shirt, keep the art exactly the same"
 }
 ```
 
@@ -602,7 +604,7 @@ Modify the lighting setup of an image.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `image` | string | required | Source image URL or base64 |
-| `light_type` | string | required | Lighting preset (see values below) |
+| `light_type` | string | "soft overcast daylight lighting" | Lighting preset (see values below) |
 | `light_direction` | string | required | `front`, `side`, `bottom`, `top-down` |
 
 **Light Types:** `midday`, `blue hour light`, `low-angle sunlight`, `sunrise light`, `spotlight on subject`, `overcast light`, `soft overcast daylight lighting`, `cloud-filtered lighting`, `fog-diffused lighting`, `side lighting`, `moonlight lighting`, `starlight nighttime`, `soft bokeh lighting`, `harsh studio lighting`
@@ -618,8 +620,7 @@ Convert a sketch or line drawing to a photorealistic image.
 **Request:**
 ```json
 {
-  "image": "sketch-base64-or-url",
-  "prompt": "optional description"
+  "image": "sketch-base64-or-url"
 }
 ```
 
@@ -689,7 +690,7 @@ Check async request status.
 **Response:**
 ```json
 {
-  "status": "IN_PROGRESS | COMPLETED | FAILED",
+  "status": "IN_PROGRESS | COMPLETED | ERROR",
   "result": {
     "image_url": "https://..."
   },
@@ -700,7 +701,8 @@ Check async request status.
 **Status Values:**
 - `IN_PROGRESS` - Still processing
 - `COMPLETED` - Success, result available
-- `FAILED` - Error occurred
+- `ERROR` - The request failed (this is the literal value; there is no `FAILED`)
+- `UNKNOWN` - No such request id
 
 **Polling Pattern:**
 ```python
@@ -713,7 +715,7 @@ def poll(status_url, api_key, timeout=120):
         data = r.json()
         if data["status"] == "COMPLETED":
             return data["result"]["image_url"]
-        if data["status"] == "FAILED":
+        if data["status"] in ("ERROR", "UNKNOWN"):
             raise Exception(data.get("error"))
         time.sleep(2)
     raise TimeoutError()

--- a/bria-ai-openclaw/skills/bria-ai/references/api-endpoints.md
+++ b/bria-ai-openclaw/skills/bria-ai/references/api-endpoints.md
@@ -148,7 +148,7 @@ position — the first is "image 1", the second "image 2", and so on:
 | `images` | array | required | 1–4 image URLs or base64 data URLs. **Order matters** — the instruction refers to them as "image 1", "image 2", … in the order they are sent |
 | `instruction` | string | required | Edit instruction in natural language. Refer to additional images by position |
 | `seed` | int | random | For reproducibility — the same images, instruction and seed reproduce the same result |
-| `aspect_ratio` | string | - | Output ratio: "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9". Honored with 2+ images; with a single image the output follows that image and the response `warning` says so. Omit it to follow the first image |
+| `aspect_ratio` | string | - | Output ratio: "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9". Honored only with 2 or more images. Do not send it on a single-image request — the output follows that image regardless and the response carries a `warning`; to change one image's ratio, use `/v2/image/edit/expand` |
 | `model_version` | string | - | Deprecated and ignored — the service picks the edit model from the request contents. A value that is sent comes back with a notice in `warning`; omit it |
 
 **Writing a multi-reference instruction:**

--- a/bria-ai-openclaw/skills/bria-ai/references/capabilities.md
+++ b/bria-ai-openclaw/skills/bria-ai/references/capabilities.md
@@ -18,6 +18,7 @@
 |------|------------|----------|
 | Generate images from text | FIBO Generate | `/v2/image/generate` |
 | Edit images by text instruction | FIBO-Edit | `/v2/image/edit` |
+| Combine 2-4 images in one edit | FIBO-Edit multi-reference | `/v2/image/edit` (ordered `images` array) |
 | Edit image region with mask | GenFill/Erase | `/v2/image/edit/genfill` |
 | Add/Replace/Remove objects | Text-based editing | `/v2/image/edit` |
 | Remove background (transparent PNG) | RMBG-2.0 | `/v2/image/edit/remove_background` |

--- a/bria-ai-openclaw/skills/bria-ai/references/capabilities.md
+++ b/bria-ai-openclaw/skills/bria-ai/references/capabilities.md
@@ -19,11 +19,11 @@
 | Generate images from text | FIBO Generate | `/v2/image/generate` |
 | Edit images by text instruction | FIBO-Edit | `/v2/image/edit` |
 | Combine 2-4 images in one edit | FIBO-Edit multi-reference | `/v2/image/edit` (ordered `images` array) |
-| Edit image region with mask | GenFill/Erase | `/v2/image/edit/genfill` |
+| Edit image region with mask | GenFill/Erase | `/v2/image/edit/gen_fill` |
 | Add/Replace/Remove objects | Text-based editing | `/v2/image/edit` |
 | Remove background (transparent PNG) | RMBG-2.0 | `/v2/image/edit/remove_background` |
 | Replace/blur/erase background | Background ops | `/v2/image/edit/replace_background` |
-| Expand/outpaint images | Outpainting | `/v2/image/edit/increase_outpaint` |
+| Expand/outpaint images | Outpainting | `/v2/image/edit/expand` |
 | Upscale image resolution | Super Resolution | `/v2/image/edit/increase_resolution` |
 | Enhance image quality | Enhancement | `/v2/image/edit/enhance` |
 | Restyle images | Restyle | `/v2/image/edit/restyle` |
@@ -32,9 +32,9 @@
 | Composite/blend images | Image Blending | `/v2/image/edit/blend` |
 | Restore old photos | Restoration | `/v2/image/edit/restore` |
 | Colorize images | Colorization | `/v2/image/edit/colorize` |
-| Sketch to photo | Sketch2Image | `/v2/image/edit/sketch2image` |
+| Sketch to photo | Sketch2Image | `/v2/image/edit/sketch_to_colored_image` |
 | Create product lifestyle shots | Lifestyle Shot | `/v1/product/lifestyle_shot_by_text` |
-| Integrate products into scenes | Product Integrate | `/v1/product/product_integrate` |
+| Integrate products into scenes | Product Integrate | `/v2/image/edit/product/integrate` |
 
 ---
 

--- a/bria-ai-openclaw/skills/bria-ai/references/code-examples/bria_client.sh
+++ b/bria-ai-openclaw/skills/bria-ai/references/code-examples/bria_client.sh
@@ -8,20 +8,28 @@
 #   RESULT=$(bria_call /v2/image/edit/remove_background "/path/to/image.png")
 #   RESULT=$(bria_call /v2/image/edit/replace_background "https://example.com/img.jpg" '"prompt":"sunset beach"')
 #   RESULT=$(bria_call /v2/image/edit "/path/to/image.png" --key images '"instruction":"make it red"')
+#   RESULT=$(bria_call /v2/image/edit "https://example.com/man.jpg" --key images \
+#     --image "https://example.com/santa.png" \
+#     '"instruction":"dress the man in image 1 in the santa outfit from image 2"')
+#
+# Each extra --image adds the next reference image, in order: the positional image is "image 1",
+# the first --image is "image 2", and so on. Only the images array (--key images) takes references.
 #
 # BRIA_API_KEY is auto-loaded from ~/.bria/credentials if not already set.
 
 BRIA_API_BASE="${BRIA_API_BASE:-https://engine.prod.bria-api.com}"
-BRIA_USER_AGENT="BriaSkills/1.3.5"
+BRIA_USER_AGENT="BriaSkills/1.3.6"
 
 bria_call() {
-  local endpoint image key extra payload result http_code body url status_url poll i
+  local endpoint image key extra payload result http_code body url status_url poll i img
+  local references=()
   endpoint="$1"; image="$2"; shift 2
 
   key="image"; extra=""
   while [ $# -gt 0 ]; do
     case "$1" in
       --key) key="$2"; shift 2 ;;
+      --image) references+=("$2"); shift 2 ;;
       *) extra="${extra:+$extra, }$1"; shift ;;
     esac
   done
@@ -36,25 +44,32 @@ bria_call() {
 
   if [ -z "$image" ]; then
     printf '{' > "$payload"
+  elif [ "$key" = "images" ]; then
+    # Written one entry at a time, in argument order: the array position is how the instruction
+    # addresses each image ("image 1", "image 2"), so nothing here may reorder them.
+    printf '{"images": [' > "$payload"
+    i=0
+    # ${arr[@]+"${arr[@]}"} expands to nothing for an empty array instead of failing under `set -u`.
+    for img in "$image" ${references[@]+"${references[@]}"}; do
+      [ "$i" -gt 0 ] && printf ', ' >> "$payload"
+      if printf '%s' "$img" | grep -qE '^https?://'; then
+        printf '"%s"' "$img" >> "$payload"
+      else
+        [ ! -f "$img" ] && { echo "ERROR: File not found: $img" >&2; return 1; }
+        printf '"' >> "$payload"
+        base64 < "$img" | tr -d '\n' >> "$payload"
+        printf '"' >> "$payload"
+      fi
+      i=$((i + 1))
+    done
+    printf ']' >> "$payload"
   elif printf '%s' "$image" | grep -qE '^https?://'; then
-    if [ "$key" = "images" ]; then
-      printf '{"images": ["%s"]' "$image" > "$payload"
-    else
-      printf '{"%s": "%s"' "$key" "$image" > "$payload"
-    fi
+    printf '{"%s": "%s"' "$key" "$image" > "$payload"
   else
     [ ! -f "$image" ] && { echo "ERROR: File not found: $image" >&2; return 1; }
-    if [ "$key" = "images" ]; then
-      printf '{"images": ["' > "$payload"
-    else
-      printf '{"%s": "' "$key" > "$payload"
-    fi
+    printf '{"%s": "' "$key" > "$payload"
     base64 < "$image" | tr -d '\n' >> "$payload"
-    if [ "$key" = "images" ]; then
-      printf '"]' >> "$payload"
-    else
-      printf '"' >> "$payload"
-    fi
+    printf '"' >> "$payload"
   fi
 
   if [ -n "$extra" ]; then

--- a/bria-ai-openclaw/skills/image-utils/SKILL.md
+++ b/bria-ai-openclaw/skills/image-utils/SKILL.md
@@ -4,7 +4,7 @@ description: Classic image manipulation with Python Pillow - resize, crop, compo
 license: MIT
 metadata:
   author: Bria AI
-  version: "1.3.5"
+  version: "1.3.6"
 ---
 
 # Image Utilities

--- a/bria-ai-openclaw/skills/image-utils/references/code-examples/image_utils.py
+++ b/bria-ai-openclaw/skills/image-utils/references/code-examples/image_utils.py
@@ -101,7 +101,7 @@ class ImageUtils:
             PIL Image object
         """
         response = requests.get(
-            url, timeout=timeout, headers={"User-Agent": "BriaSkills/1.3.5"}
+            url, timeout=timeout, headers={"User-Agent": "BriaSkills/1.3.6"}
         )
         response.raise_for_status()
         return Image.open(io.BytesIO(response.content))

--- a/bria-ai-openclaw/skills/remove-background/SKILL.md
+++ b/bria-ai-openclaw/skills/remove-background/SKILL.md
@@ -4,7 +4,7 @@ description: Remove backgrounds from images — background removal API for trans
 license: MIT
 metadata:
   author: Bria AI
-  version: "1.3.5"
+  version: "1.3.6"
 ---
 
 # Remove Background — Transparent PNGs & Cutouts with RMBG 2.0

--- a/bria-ai-openclaw/skills/remove-background/references/api-endpoints.md
+++ b/bria-ai-openclaw/skills/remove-background/references/api-endpoints.md
@@ -8,10 +8,10 @@
 ```
 api_token: YOUR_BRIA_API_KEY
 Content-Type: application/json
-User-Agent: BriaSkills/1.3.5
+User-Agent: BriaSkills/1.3.6
 ```
 
-> **Required:** Always include the `User-Agent: BriaSkills/1.3.5` header in every API call, including status polling requests.
+> **Required:** Always include the `User-Agent: BriaSkills/1.3.6` header in every API call, including status polling requests.
 
 ---
 

--- a/bria-ai-openclaw/skills/remove-background/references/code-examples/bria_client.sh
+++ b/bria-ai-openclaw/skills/remove-background/references/code-examples/bria_client.sh
@@ -12,7 +12,7 @@
 # BRIA_API_KEY is auto-loaded from ~/.bria/credentials if not already set.
 
 BRIA_API_BASE="${BRIA_API_BASE:-https://engine.prod.bria-api.com}"
-BRIA_USER_AGENT="BriaSkills/1.3.5"
+BRIA_USER_AGENT="BriaSkills/1.3.6"
 
 bria_call() {
   local endpoint image key extra payload result http_code body url status_url poll i

--- a/bria-ai-openclaw/skills/vgl/SKILL.md
+++ b/bria-ai-openclaw/skills/vgl/SKILL.md
@@ -4,7 +4,7 @@ description: Maximum control over AI image generation — write structured VGL (
 license: MIT
 metadata:
   author: Bria AI
-  version: "1.3.5"
+  version: "1.3.6"
 ---
 
 # Bria VGL — Full Control Over Image Generation
@@ -266,7 +266,7 @@ Only change what the edit strictly requires.
 curl -X POST "https://engine.prod.bria-api.com/v2/image/generate" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.3.5" \
+  -H "User-Agent: BriaSkills/1.3.6" \
   -d '{
     "structured_prompt": "{\"short_description\": \"...\", ...}",
     "prompt": "Generate this scene",

--- a/bria-ai-openclaw/skills/video-remove-background/SKILL.md
+++ b/bria-ai-openclaw/skills/video-remove-background/SKILL.md
@@ -4,7 +4,7 @@ description: Remove backgrounds from videos — video background removal API for
 license: MIT
 metadata:
   author: Bria AI
-  version: "1.3.5"
+  version: "1.3.6"
 ---
 
 # Video Remove Background — Transparent Videos & Alpha-Channel Clips

--- a/bria-ai-openclaw/skills/video-remove-background/references/api-endpoints.md
+++ b/bria-ai-openclaw/skills/video-remove-background/references/api-endpoints.md
@@ -8,10 +8,10 @@
 ```
 api_token: YOUR_BRIA_API_KEY
 Content-Type: application/json
-User-Agent: BriaSkills/1.3.5
+User-Agent: BriaSkills/1.3.6
 ```
 
-> **Required:** Always include the `User-Agent: BriaSkills/1.3.5` header in every API call, including status polling requests.
+> **Required:** Always include the `User-Agent: BriaSkills/1.3.6` header in every API call, including status polling requests.
 
 ---
 

--- a/bria-ai-openclaw/skills/video-remove-background/references/code-examples/bria_video_client.sh
+++ b/bria-ai-openclaw/skills/video-remove-background/references/code-examples/bria_video_client.sh
@@ -12,7 +12,7 @@
 # BRIA_API_KEY is auto-loaded from ~/.bria/credentials if not already set.
 
 BRIA_API_BASE="${BRIA_API_BASE:-https://engine.prod.bria-api.com}"
-BRIA_USER_AGENT="BriaSkills/1.3.5"
+BRIA_USER_AGENT="BriaSkills/1.3.6"
 BRIA_POLL_INTERVAL="${BRIA_POLL_INTERVAL:-5}"    # seconds between status polls
 BRIA_POLL_ATTEMPTS="${BRIA_POLL_ATTEMPTS:-120}"  # max polls (default 120 x 5s = 10 min)
 

--- a/kiro/bria-ai/POWER.md
+++ b/kiro/bria-ai/POWER.md
@@ -223,7 +223,9 @@ position in the instruction: *"dress the man in image 1 in the santa outfit from
 each reference contributes ("the background of image 3"), in plain prose. A single-image edit needs
 no positional wording: *"change the mug color to red"*.
 
-**Generation options:** Aspect ratios `1:1`, `16:9`, `4:3`, `9:16`, `3:4`. Resolution `1MP` (default) or `4MP` (more detail, +30s). Pass `"sync": true` for single images.
+**Generation options:** Aspect ratios `1:1`, `16:9`, `4:3`, `9:16`, `3:4`. Resolution `1MP` (default) or `4MP` (more detail, +30s). Pass `"sync": true` for a single generated image. Editing endpoints are the other way round —
+they answer with a `status_url` you poll, and `"sync": true` on an edit fails with a gateway
+timeout.
 
 > **Advanced**: For precise control over generation, use the **vgl** power for structured VGL JSON prompts instead of natural language.
 

--- a/kiro/bria-ai/POWER.md
+++ b/kiro/bria-ai/POWER.md
@@ -149,6 +149,7 @@ Interpret the output:
 |------|------------|----------|
 | Generate images from text | FIBO Generate | Hero images, product shots, illustrations, social media images, banners |
 | Edit images by text instruction | FIBO-Edit | Change colors, modify objects, transform scenes |
+| Combine 2–4 images in one edit | FIBO-Edit multi-reference | Put the outfit, product, logo, style, or background of one image into another |
 | Edit image region with mask | GenFill/Erase | Precise inpainting, add/replace specific regions |
 | Add/Replace/Remove objects | Text-based editing | Add vase, replace apple with pear, remove table |
 | Remove background (transparent PNG) | RMBG-2.0 | Extract subjects for overlays, logos, cutouts |
@@ -187,6 +188,11 @@ RESULT=$(bria_call /v2/image/edit/replace_background "https://example.com/img.jp
 # Edit image (uses images array — pass --key images)
 RESULT=$(bria_call /v2/image/edit "/path/to/image.png" --key images '"instruction": "make it look warmer"')
 
+# Edit with reference images — each --image adds the next one, in order
+RESULT=$(bria_call /v2/image/edit "https://example.com/man.jpg" --key images \
+  --image "https://example.com/santa.png" \
+  '"instruction": "dress the man in image 1 in the santa outfit from image 2"')
+
 # Upscale
 RESULT=$(bria_call /v2/image/edit/increase_resolution "https://example.com/img.jpg" '"scale": 4')
 
@@ -205,8 +211,17 @@ echo "$RESULT"
 **Calling convention:** `bria_call <endpoint> <image_or_empty> [--key <json_key>] [extra JSON fields...]`
 - Pass a URL, local file path, or `""` (empty) for endpoints without image input
 - Use `--key images` when the endpoint expects an `images` array instead of `image`
+- Add `--image <url_or_path>` once per extra reference image (`--key images`, up to 4 in total).
+  Order is preserved: the positional image is "image 1", the first `--image` is "image 2", …
 - Extra JSON fields are appended as key-value pairs: `'"key": "value"'`
 - Returns the result image URL on success, or prints an error to stderr
+
+**Editing with several images (2–4):** reach for a second image when the look the user wants
+already exists as a picture — a specific outfit, product, logo, or scene — instead of something you
+can describe in words. Put the image being edited first, references after it, and address them by
+position in the instruction: *"dress the man in image 1 in the santa outfit from image 2"*. Say what
+each reference contributes ("the background of image 3"), in plain prose. A single-image edit needs
+no positional wording: *"change the mug color to red"*.
 
 **Generation options:** Aspect ratios `1:1`, `16:9`, `4:3`, `9:16`, `3:4`. Resolution `1MP` (default) or `4MP` (more detail, +30s). Pass `"sync": true` for single images.
 
@@ -316,7 +331,7 @@ All requests need `api_token` header:
 api_token: YOUR_BRIA_API_KEY
 User-Agent: BriaSkills/<version>
 ```
-> **Required:** Always include the `User-Agent: BriaSkills/<version>` header (where `<version>` is the current skill version, e.g. `BriaSkills/1.3.5`) in every API call, including status polling requests.
+> **Required:** Always include the `User-Agent: BriaSkills/<version>` header (where `<version>` is the current skill version, e.g. `BriaSkills/1.3.6`) in every API call, including status polling requests.
 
 ---
 
@@ -339,6 +354,6 @@ User-Agent: BriaSkills/<version>
 
 **Original Work:** This power is converted from the [bria-skill](https://github.com/bria-ai/bria-skill) Claude Code skill by Bria AI.
 
-**Source Version:** Based on version 1.3.5.
+**Source Version:** Based on version 1.3.6.
 
 **Update Frequency:** This power will be updated periodically.

--- a/kiro/bria-ai/POWER.md
+++ b/kiro/bria-ai/POWER.md
@@ -194,7 +194,7 @@ RESULT=$(bria_call /v2/image/edit "https://example.com/man.jpg" --key images \
   '"instruction": "dress the man in image 1 in the santa outfit from image 2"')
 
 # Upscale
-RESULT=$(bria_call /v2/image/edit/increase_resolution "https://example.com/img.jpg" '"scale": 4')
+RESULT=$(bria_call /v2/image/edit/increase_resolution "https://example.com/img.jpg" '"desired_increase": 4')
 
 # Lifestyle shot
 RESULT=$(bria_call /v1/product/lifestyle_shot_by_text "/path/to/product.png" '"scene_description": "modern kitchen countertop"')

--- a/kiro/bria-ai/steering/api-endpoints.md
+++ b/kiro/bria-ai/steering/api-endpoints.md
@@ -157,8 +157,12 @@ position — the first is "image 1", the second "image 2", and so on:
   just that it exists.
 - Plain prose, plain words — "image 1", "image 2". No brackets, tags, or markup.
 
+This endpoint is asynchronous: it answers with `request_id` and `status_url`, which you poll. Do
+not send `"sync": true` here — an instruction edit takes longer than a single response is allowed to
+take, so a synchronous request fails with a gateway timeout even though the job itself is fine.
+
 **Constraints** — each returns 422 with a readable message:
-- More than 4 images.
+- More than 4 images. Trim the set before sending; the request is refused, not truncated.
 - A `mask` together with 2 or more images (masked edits are single-image only).
 - 2 or more images together with a tailored `model_id` or `model_version: FIBO_BBQ` — both of those
   run on the single-reference model.

--- a/kiro/bria-ai/steering/api-endpoints.md
+++ b/kiro/bria-ai/steering/api-endpoints.md
@@ -255,7 +255,8 @@ Upscale image resolution.
 ```json
 {
   "image": "https://source-image-url",
-  "scale": 2
+  "desired_increase": 4,
+  "preserve_alpha": true
 }
 ```
 
@@ -264,7 +265,43 @@ Upscale image resolution.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `image` | string | required | Source image URL |
-| `scale` | int | 2 | Upscale factor (2 or 4) |
+| `desired_increase` | int | 2 | Upscale factor, range 2–4 |
+| `preserve_alpha` | bool | false | Preserve transparency. Set `true` when input has an alpha channel — the API upscales and recombines the alpha server-side, so you don't need to handle it client-side. |
+
+### POST /v1/product/cutout
+
+Remove the background from a product photo → clean transparent PNG. The `/v1/product/*` endpoints take `image_url` (URL) or `file` (base64).
+
+**Request:**
+```json
+{ "image_url": "https://…/raw.jpg" }
+```
+Response: `{ "result_url": "https://…png" }` (synchronous).
+
+### POST /v1/product/packshot
+
+Standardized 2000×2000 packshot on a solid/clean background.
+
+| Parameter | Type | Notes |
+|-----------|------|-------|
+| `image_url` / `file` | string | Product image (a cutout is recommended) |
+| `background_color` | string | Hex like `#FFFFFF`, or `transparent` |
+| `sku` | string | Optional label/id |
+
+Response: `{ "result_url": "…" }` (synchronous).
+
+### POST /v1/product/shadow
+
+Add a realistic shadow to a product cutout.
+
+| Parameter | Type | Notes |
+|-----------|------|-------|
+| `image_url` / `file` | string | Product cutout |
+| `type` | string | `regular` (drop) or `float` (elliptical) |
+| `background_color` | string | Hex or `transparent` |
+| `shadow_intensity` | int | 0–100 (approx) |
+
+Response: `{ "result_url": "…" }` (synchronous).
 
 ### POST /v1/product/lifestyle_shot_by_text
 
@@ -274,10 +311,38 @@ Place a product in a lifestyle scene using text description.
 ```json
 {
   "file": "BASE64_ENCODED_IMAGE",
-  "prompt": "modern kitchen countertop, natural lighting",
+  "scene_description": "modern kitchen countertop, natural lighting",
   "placement_type": "automatic"
 }
 ```
+
+**Parameters:**
+
+| Parameter | Type | Notes |
+|-----------|------|-------|
+| `image_url` / `file` | string | Product (cutout recommended) |
+| `scene_description` | string | Environment + lighting + mood |
+| `mode` | string | `base`, `high_control` (recommended), `fast` |
+| `placement_type` | string | `automatic`, `automatic_aspect_ratio`, `manual_placement`, `custom_coordinates`, `manual_padding`, `original` |
+| `aspect_ratio` | string | e.g. `1:1`, `4:5`, `16:9` (with `automatic_aspect_ratio`) |
+| `num_results` | int | Number of variations |
+| `sync` | bool | `true` returns results inline |
+| `optimize_description` | bool | Let Bria refine the prompt |
+
+Response: `{ "result": [[ "image_url", "seed", "session_id" ], …] }` — extract `result[0][0]`.
+
+### POST /v1/product/lifestyle_shot_by_image
+
+Same as `lifestyle_shot_by_text`, but the scene comes from a reference background image instead of a text description.
+
+| Parameter | Type | Notes |
+|-----------|------|-------|
+| `image_url` / `file` | string | Product |
+| `ref_image_urls` | array | One or more background reference URLs |
+| `placement_type` | string | see above |
+| `num_results` | int | variations |
+
+Response: `{ "result": [[ "image_url", … ], …] }`.
 
 ### POST /image/edit/product/integrate
 
@@ -333,6 +398,63 @@ Integrate and embed one or more products into a predefined scene at precise user
   "status_url": "https://..."
 }
 ```
+
+### POST /v2/image/edit/product_dimensions
+
+Render a marketplace-ready dimension image from a product photo: the background is removed automatically, then measurement callout lines + labels are drawn around the product, with an optional title and optional weight/capacity text. Three visual styles. Useful for e-commerce listings (Amazon-style "dimensions" images).
+
+**Request:**
+```json
+{
+  "image": "https://product-image-url",
+  "style": "default",
+  "dimensions": [
+    {"name": "height", "value": 12, "unit": "cm", "position": "left"},
+    {"name": "width_bottom", "value": 6, "unit": "cm", "position": "bottom"}
+  ],
+  "title": "Gummies Bottle",
+  "weight": {"value": 250, "unit": "g", "label": "Net Weight"},
+  "capacity": {"value": 500, "unit": "ml"},
+  "background": "white",
+  "output_format": "png"
+}
+```
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `image` | string | required | Product photo URL or base64. Background is removed automatically — no pre-cutout needed |
+| `dimensions` | array | required | One or more dimension callouts (min 1) |
+| `dimensions[].name` | string | required | `height`, `width_bottom`, or `width_top` (`length`/`depth` not currently enabled) |
+| `dimensions[].value` | float | required | Physical measurement value (must be > 0) |
+| `dimensions[].unit` | string | required | `mm`, `cm`, `m`, `in`, `"` (inches), `ft`, `'` (feet) |
+| `dimensions[].position` | string | per-name | Callout side: `top`, `bottom`, `left`, `right`. Defaults: height→`left`, width_bottom→`bottom`, width_top→`top` |
+| `style` | string | required | `default`, `childlike`, or `elegant` |
+| `units_display` | string | "single" | `single`, `dual_bullet`, `dual_slash`, `dual_parens`. For dual modes, supply two `dimensions` entries with the same `name`+`position` but different `unit` (e.g. `in` and `cm`) — they merge into one dual-unit label |
+| `background` | string | "white" | `white`, `cream`, `charcoal`, or a hex color (e.g. `#f5f0e8`) |
+| `title` | string | - | Optional headline above the product (max 80 chars) |
+| `title_position` | string | "top_center" | `top_left`, `top_center`, `top_right` |
+| `weight` | object | - | Optional weight callout below the product |
+| `weight.value` | float | required* | Weight value (> 0) *if `weight` is provided |
+| `weight.unit` | string | required* | `lb`, `oz`, `g`, `kg` |
+| `weight.label` | string | "Weight" | `Weight` or `Net Weight` |
+| `capacity` | object | - | Optional capacity callout below the product |
+| `capacity.value` | float | required* | Capacity value (> 0) *if `capacity` is provided |
+| `capacity.unit` | string | required* | `fl_oz`, `ml`, `l`, `qt`, `gal`, `cups` |
+| `output_format` | string | "png" | `png`, `jpeg`, or `dual` (composite PNG + a transparent overlay-only PNG, returned as two images) |
+| `output_size` | int | 2200 | Square output edge length in px (256–2200) |
+| `proportional_lines` | bool | true | Scale each dimension line's length to its measurement (the largest per axis spans the product) |
+
+**Async Response (202):**
+```json
+{
+  "request_id": "uuid",
+  "status_url": "https://..."
+}
+```
+
+Poll `status_url` for the result. `dual` output returns two images: `[composite, overlay]`.
 
 ---
 

--- a/kiro/bria-ai/steering/api-endpoints.md
+++ b/kiro/bria-ai/steering/api-endpoints.md
@@ -11,7 +11,7 @@ Content-Type: application/json
 User-Agent: BriaSkills/<version>
 ```
 
-> **Required:** Always include the `User-Agent: BriaSkills/<version>` header (where `<version>` is the current skill version from `package.json`, e.g. `BriaSkills/1.3.5`) in every API call, including status polling requests.
+> **Required:** Always include the `User-Agent: BriaSkills/<version>` header (where `<version>` is the current skill version from `package.json`, e.g. `BriaSkills/1.3.6`) in every API call, including status polling requests.
 
 ---
 
@@ -120,7 +120,9 @@ Remove background from image. Returns PNG with transparency.
 
 ### POST /v2/image/edit
 
-Edit an image using natural language instructions. No mask required.
+Edit an image with a natural language instruction — no mask required. Send one image to change it,
+or 2–4 images to combine them: the subject from one with an outfit, product, style, or background
+from another.
 
 **Request:**
 ```json
@@ -130,12 +132,53 @@ Edit an image using natural language instructions. No mask required.
 }
 ```
 
+**Multi-reference request.** `images` is ordered, and the instruction addresses each entry by its
+position — the first is "image 1", the second "image 2", and so on:
+```json
+{
+  "images": ["https://man-image-url", "https://santa-outfit-image-url"],
+  "instruction": "dress the man in image 1 in the santa outfit from image 2",
+  "seed": 1234
+}
+```
+
 **Parameters:**
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `images` | array | required | Array of image URLs or base64 data URLs |
-| `instruction` | string | required | Edit instruction in natural language |
+| `images` | array | required | 1–4 image URLs or base64 data URLs. **Order matters** — the instruction refers to them as "image 1", "image 2", … in the order they are sent |
+| `instruction` | string | required | Edit instruction in natural language. Refer to additional images by position |
+| `seed` | int | random | For reproducibility — the same images, instruction and seed reproduce the same result |
+| `aspect_ratio` | string | - | Output ratio: "1:1", "4:3", "16:9", "3:4", "9:16". Honored with 2+ images; with a single image the output follows that image and the response `warning` says so. Omit it to follow the first image |
+| `model_version` | string | - | Deprecated and ignored — the service picks the edit model from the request contents. A value that is sent comes back with a notice in `warning`; omit it |
+
+**Writing a multi-reference instruction:**
+- Put the image being edited first and the references after it.
+- Say what each reference contributes ("the outfit from image 2", "the background of image 3"), not
+  just that it exists.
+- Plain prose, plain words — "image 1", "image 2". No brackets, tags, or markup.
+
+**Constraints** — each returns 422 with a readable message:
+- More than 4 images.
+- A `mask` together with 2 or more images (masked edits are single-image only).
+- 2 or more images together with a tailored `model_id` or `model_version: FIBO_BBQ` — both of those
+  run on the single-reference model.
+
+**Completed Result:**
+```json
+{
+  "status": "COMPLETED",
+  "result": {
+    "image_url": "https://...",
+    "seed": 1234,
+    "warning": null
+  }
+}
+```
+
+`warning` is set when a parameter was accepted but not honored — `aspect_ratio` on a single-image
+request, a supplied `model_version`, or a tuning parameter the serving model does not read. Relay it
+to the user rather than dropping it.
 
 ### POST /v2/image/edit/gen_fill
 
@@ -664,7 +707,7 @@ Check async request status.
 import requests, time
 
 def poll(status_url, api_key, timeout=120):
-    headers = {"api_token": api_key, "User-Agent": "BriaSkills/1.3.5"}
+    headers = {"api_token": api_key, "User-Agent": "BriaSkills/1.3.6"}
     for _ in range(timeout // 2):
         r = requests.get(status_url, headers=headers)
         data = r.json()

--- a/kiro/bria-ai/steering/api-endpoints.md
+++ b/kiro/bria-ai/steering/api-endpoints.md
@@ -28,7 +28,6 @@ Generate images from text prompts using FIBO's structured prompt system.
   "aspect_ratio": "1:1",
   "resolution": "1MP",
   "negative_prompt": "string",
-  "num_results": 1,
   "seed": null
 }
 ```
@@ -38,22 +37,22 @@ Generate images from text prompts using FIBO's structured prompt system.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `prompt` | string | required* | Image description (* or use `structured_prompt`) |
-| `aspect_ratio` | string | "1:1" | "1:1", "4:3", "16:9", "3:4", "9:16" |
+| `aspect_ratio` | string | "1:1" | "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9" |
 | `resolution` | string | "1MP" | Output image resolution. "1MP" or "4MP". "4MP" improves image details, especially for photorealism, but increases latency by ~30 seconds. |
 | `negative_prompt` | string | - | What to exclude |
-| `num_results` | int | 1 | Number of images (1-4) |
 | `seed` | int | random | For reproducibility |
 | `structured_prompt` | string | - | JSON from previous generation (for refinement). Use with `prompt` to refine, or alone with `seed` to recreate. |
-| `image_url` | string | - | Reference image (for inspire mode) |
+| `images` | array | - | Reference image for inspire mode: an array holding one image URL or base64 string |
 
-**Input Combination Rules** (mutually exclusive):
+**Input Combinations** — at least one of `prompt`, `images` or `structured_prompt` is required:
 - `prompt` — Generate from text
-- `image_url` — Generate inspired by a reference image
-- `image_url` + `prompt` — Generate inspired by image, guided by text
+- `images` — Generate inspired by a reference image
+- `images` + `prompt` — Generate inspired by image, guided by text
 - `structured_prompt` + `seed` — Recreate a previous image exactly
 - `structured_prompt` + `prompt` + `seed` — Refine a previous image with new instructions
 
-All combinations support `aspect_ratio`, `negative_prompt`, `num_results`, and `seed`.
+All combinations support `aspect_ratio`, `negative_prompt` and `seed`. Note that `"sync": true`
+cannot be combined with `"resolution": "4MP"` — that pairing is rejected.
 
 **Response:**
 ```json
@@ -149,7 +148,7 @@ position — the first is "image 1", the second "image 2", and so on:
 | `images` | array | required | 1–4 image URLs or base64 data URLs. **Order matters** — the instruction refers to them as "image 1", "image 2", … in the order they are sent |
 | `instruction` | string | required | Edit instruction in natural language. Refer to additional images by position |
 | `seed` | int | random | For reproducibility — the same images, instruction and seed reproduce the same result |
-| `aspect_ratio` | string | - | Output ratio: "1:1", "4:3", "16:9", "3:4", "9:16". Honored with 2+ images; with a single image the output follows that image and the response `warning` says so. Omit it to follow the first image |
+| `aspect_ratio` | string | - | Output ratio: "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9". Honored with 2+ images; with a single image the output follows that image and the response `warning` says so. Omit it to follow the first image |
 | `model_version` | string | - | Deprecated and ignored — the service picks the edit model from the request contents. A value that is sent comes back with a notice in `warning`; omit it |
 
 **Writing a multi-reference instruction:**
@@ -171,10 +170,15 @@ position — the first is "image 1", the second "image 2", and so on:
   "result": {
     "image_url": "https://...",
     "seed": 1234,
+    "structured_prompt": "{...}",
     "warning": null
   }
 }
 ```
+
+The result also carries the structured instruction the edit was rendered from — named
+`structured_prompt` on a polled result and `structured_instruction` on an inline `"sync": true`
+response. Read whichever is present.
 
 `warning` is set when a parameter was accepted but not honored — `aspect_ratio` on a single-image
 request, a supplied `model_version`, or a tuning parameter the serving model does not read. Relay it
@@ -190,9 +194,7 @@ Generate content in a masked region (inpainting).
   "image": "https://source-image-url",
   "mask": "https://mask-image-url",
   "prompt": "what to generate",
-  "mask_type": "manual",
-  "negative_prompt": "string",
-  "num_results": 1
+  "mask_type": "manual"
 }
 ```
 
@@ -204,8 +206,6 @@ Generate content in a masked region (inpainting).
 | `mask` | string | required | Mask URL (white=edit, black=keep) |
 | `prompt` | string | required | What to generate in masked area |
 | `mask_type` | string | "manual" | "manual" or "automatic" |
-| `negative_prompt` | string | - | What to avoid |
-| `num_results` | int | 1 | Number of variations |
 
 **Mask Requirements:**
 - White pixels (255) = area to edit
@@ -276,7 +276,7 @@ Expand/outpaint an image to extend its boundaries.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `image` | string | required | Source image URL or base64 string |
-| `aspect_ratio` | string | required | Target ratio: "1:1", "4:3", "16:9", "3:4", "9:16" |
+| `aspect_ratio` | string \| float | - | Target ratio: "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", or a float. Omit it and pass `canvas_size` instead |
 | `prompt` | string | - | Optional - describe content to generate |
 
 ### POST /v2/image/edit/enhance
@@ -308,8 +308,8 @@ Upscale image resolution.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `image` | string | required | Source image URL |
-| `desired_increase` | int | 2 | Upscale factor, range 2–4 |
-| `preserve_alpha` | bool | false | Preserve transparency. Set `true` when input has an alpha channel — the API upscales and recombines the alpha server-side, so you don't need to handle it client-side. |
+| `desired_increase` | int | 2 | Upscale factor: 2 or 4 |
+| `preserve_alpha` | bool | true | Preserve transparency. Set `true` when input has an alpha channel — the API upscales and recombines the alpha server-side, so you don't need to handle it client-side. |
 
 ### POST /v1/product/cutout
 
@@ -387,7 +387,7 @@ Same as `lifestyle_shot_by_text`, but the scene comes from a reference backgroun
 
 Response: `{ "result": [[ "image_url", … ], …] }`.
 
-### POST /image/edit/product/integrate
+### POST /v2/image/edit/product/integrate
 
 Integrate and embed one or more products into a predefined scene at precise user-defined coordinates. The product is automatically matched to the scene's lighting, perspective, and aesthetics. Products are automatically cut out from their background as part of the pipeline.
 
@@ -442,9 +442,12 @@ Integrate and embed one or more products into a predefined scene at precise user
 }
 ```
 
-### POST /v2/image/edit/product_dimensions
+### POST /v2/image/edit/product/generate/dimensions
 
-Render a marketplace-ready dimension image from a product photo: the background is removed automatically, then measurement callout lines + labels are drawn around the product, with an optional title and optional weight/capacity text. Three visual styles. Useful for e-commerce listings (Amazon-style "dimensions" images).
+Render a marketplace-ready dimension image from a product photo. (The older
+`/v2/image/edit/product_dimensions` path still works but is deprecated — use this one.)
+
+How it works: the background is removed automatically, then measurement callout lines + labels are drawn around the product, with an optional title and optional weight/capacity text. Three visual styles. Useful for e-commerce listings (Amazon-style "dimensions" images).
 
 **Request:**
 ```json
@@ -551,8 +554,7 @@ Blend/merge images or apply textures.
 ```json
 {
   "image": "base64-or-url",
-  "overlay": "texture-or-art-url",
-  "instruction": "Place the art on the shirt, keep the art exactly the same"
+  "instruction": "Place the art from this image on the shirt, keep the art exactly the same"
 }
 ```
 
@@ -602,7 +604,7 @@ Modify the lighting setup of an image.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `image` | string | required | Source image URL or base64 |
-| `light_type` | string | required | Lighting preset (see values below) |
+| `light_type` | string | "soft overcast daylight lighting" | Lighting preset (see values below) |
 | `light_direction` | string | required | `front`, `side`, `bottom`, `top-down` |
 
 **Light Types:** `midday`, `blue hour light`, `low-angle sunlight`, `sunrise light`, `spotlight on subject`, `overcast light`, `soft overcast daylight lighting`, `cloud-filtered lighting`, `fog-diffused lighting`, `side lighting`, `moonlight lighting`, `starlight nighttime`, `soft bokeh lighting`, `harsh studio lighting`
@@ -618,8 +620,7 @@ Convert a sketch or line drawing to a photorealistic image.
 **Request:**
 ```json
 {
-  "image": "sketch-base64-or-url",
-  "prompt": "optional description"
+  "image": "sketch-base64-or-url"
 }
 ```
 
@@ -689,7 +690,7 @@ Check async request status.
 **Response:**
 ```json
 {
-  "status": "IN_PROGRESS | COMPLETED | FAILED",
+  "status": "IN_PROGRESS | COMPLETED | ERROR",
   "result": {
     "image_url": "https://..."
   },
@@ -700,7 +701,8 @@ Check async request status.
 **Status Values:**
 - `IN_PROGRESS` - Still processing
 - `COMPLETED` - Success, result available
-- `FAILED` - Error occurred
+- `ERROR` - The request failed (this is the literal value; there is no `FAILED`)
+- `UNKNOWN` - No such request id
 
 **Polling Pattern:**
 ```python
@@ -713,7 +715,7 @@ def poll(status_url, api_key, timeout=120):
         data = r.json()
         if data["status"] == "COMPLETED":
             return data["result"]["image_url"]
-        if data["status"] == "FAILED":
+        if data["status"] in ("ERROR", "UNKNOWN"):
             raise Exception(data.get("error"))
         time.sleep(2)
     raise TimeoutError()

--- a/kiro/bria-ai/steering/api-endpoints.md
+++ b/kiro/bria-ai/steering/api-endpoints.md
@@ -148,7 +148,7 @@ position — the first is "image 1", the second "image 2", and so on:
 | `images` | array | required | 1–4 image URLs or base64 data URLs. **Order matters** — the instruction refers to them as "image 1", "image 2", … in the order they are sent |
 | `instruction` | string | required | Edit instruction in natural language. Refer to additional images by position |
 | `seed` | int | random | For reproducibility — the same images, instruction and seed reproduce the same result |
-| `aspect_ratio` | string | - | Output ratio: "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9". Honored with 2+ images; with a single image the output follows that image and the response `warning` says so. Omit it to follow the first image |
+| `aspect_ratio` | string | - | Output ratio: "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9". Honored only with 2 or more images. Do not send it on a single-image request — the output follows that image regardless and the response carries a `warning`; to change one image's ratio, use `/v2/image/edit/expand` |
 | `model_version` | string | - | Deprecated and ignored — the service picks the edit model from the request contents. A value that is sent comes back with a notice in `warning`; omit it |
 
 **Writing a multi-reference instruction:**

--- a/kiro/bria-ai/steering/bria-client-bash.sh
+++ b/kiro/bria-ai/steering/bria-client-bash.sh
@@ -25,7 +25,7 @@ BRIA_BASE_URL="${BRIA_BASE_URL:-https://engine.prod.bria-api.com}"
 BRIA_API_KEY="${BRIA_API_KEY:-}"
 BRIA_POLL_INTERVAL="${BRIA_POLL_INTERVAL:-2}"
 BRIA_TIMEOUT="${BRIA_TIMEOUT:-120}"
-BRIA_USER_AGENT="BriaSkills/1.3.5"
+BRIA_USER_AGENT="BriaSkills/1.3.6"
 
 # ==================== Helper Functions ====================
 
@@ -427,16 +427,37 @@ bria_blur_background() {
 }
 
 bria_edit_image() {
-  local image_url
-  image_url=$(bria_resolve_image "$1" "data_url")
-  local instruction="$2"
-  local mask_url="${3:-}"
+  # Usage: bria_edit_image <image> <instruction> [mask_url] [--image <reference>]...
+  # The images array is ordered: <image> is "image 1", each --image adds the next reference.
+  local references=() ref image_url="" instruction="" mask_url="" seen=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --image) references+=("$2"); shift 2 ;;
+      # Assigned by position rather than read out of an array: bash indexes arrays from 0 and
+      # zsh from 1, and this file gets sourced from both.
+      *)
+        case "$seen" in
+          0) image_url="$1" ;;
+          1) instruction="$1" ;;
+          2) mask_url="$1" ;;
+        esac
+        seen=$((seen + 1)); shift ;;
+    esac
+  done
+
+  image_url=$(bria_resolve_image "$image_url" "data_url")
 
   local data
   data=$(jq -n \
     --arg image "$image_url" \
     --arg inst "$instruction" \
     '{images: [$image], instruction: $inst}')
+
+  if [[ ${#references[@]} -gt 0 ]]; then
+    for ref in "${references[@]}"; do
+      data=$(echo "$data" | jq --arg ref "$(bria_resolve_image "$ref" "data_url")" '.images += [$ref]')
+    done
+  fi
 
   if [[ -n "$mask_url" ]]; then
     local resolved_mask
@@ -642,7 +663,7 @@ print_curl_examples() {
 curl -X POST "https://engine.prod.bria-api.com/v2/image/generate" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.3.5" \
+  -H "User-Agent: BriaSkills/1.3.6" \
   -d '{
     "prompt": "Modern tech startup office, developers collaborating",
     "aspect_ratio": "16:9",
@@ -654,13 +675,13 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/generate" \
 # --- Poll Status (replace STATUS_URL) ---
 curl -X GET "STATUS_URL" \
   -H "api_token: $BRIA_API_KEY" \
-  -H "User-Agent: BriaSkills/1.3.5"
+  -H "User-Agent: BriaSkills/1.3.6"
 
 # --- Remove Background ---
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/remove_background" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.3.5" \
+  -H "User-Agent: BriaSkills/1.3.6" \
   -d '{
     "image": "https://example.com/image.jpg"
   }'
@@ -669,7 +690,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/remove_background" 
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/gen_fill" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.3.5" \
+  -H "User-Agent: BriaSkills/1.3.6" \
   -d '{
     "image": "https://example.com/image.jpg",
     "mask": "https://example.com/mask.png",
@@ -681,7 +702,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/gen_fill" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/erase" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.3.5" \
+  -H "User-Agent: BriaSkills/1.3.6" \
   -d '{
     "image": "https://example.com/image.jpg",
     "mask": "https://example.com/mask.png"
@@ -691,7 +712,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/erase" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/replace_background" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.3.5" \
+  -H "User-Agent: BriaSkills/1.3.6" \
   -d '{
     "image": "https://example.com/image.jpg",
     "prompt": "tropical beach at sunset"
@@ -701,7 +722,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/replace_background"
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/expand" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.3.5" \
+  -H "User-Agent: BriaSkills/1.3.6" \
   -d '{
     "image": "https://example.com/image.jpg",
     "aspect_ratio": "16:9",
@@ -712,7 +733,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/expand" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/enhance" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.3.5" \
+  -H "User-Agent: BriaSkills/1.3.6" \
   -d '{
     "image": "https://example.com/image.jpg"
   }'
@@ -721,7 +742,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/enhance" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/increase_resolution" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.3.5" \
+  -H "User-Agent: BriaSkills/1.3.6" \
   -d '{
     "image": "https://example.com/image.jpg",
     "scale": 2
@@ -731,7 +752,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/increase_resolution
 curl -X POST "https://engine.prod.bria-api.com/v1/product/lifestyle_shot_by_text" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.3.5" \
+  -H "User-Agent: BriaSkills/1.3.6" \
   -d '{
     "file": "BASE64_ENCODED_IMAGE",
     "prompt": "modern kitchen countertop, morning light",
@@ -742,7 +763,7 @@ curl -X POST "https://engine.prod.bria-api.com/v1/product/lifestyle_shot_by_text
 curl -X POST "https://engine.prod.bria-api.com/image/edit/product/integrate" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.3.5" \
+  -H "User-Agent: BriaSkills/1.3.6" \
   -d '{
     "scene": "https://example.com/scene.jpg",
     "products": [
@@ -757,7 +778,7 @@ curl -X POST "https://engine.prod.bria-api.com/image/edit/product/integrate" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.3.5" \
+  -H "User-Agent: BriaSkills/1.3.6" \
   -d '{
     "images": ["https://example.com/image.jpg"],
     "instruction": "change the mug to red"
@@ -767,7 +788,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/add_object_by_text" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.3.5" \
+  -H "User-Agent: BriaSkills/1.3.6" \
   -d '{
     "image": "https://example.com/image.jpg",
     "instruction": "Place a red vase on the table"
@@ -777,7 +798,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/add_object_by_text"
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/replace_object_by_text" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.3.5" \
+  -H "User-Agent: BriaSkills/1.3.6" \
   -d '{
     "image": "https://example.com/image.jpg",
     "instruction": "Replace the red apple with a green pear"
@@ -787,7 +808,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/replace_object_by_t
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/erase_by_text" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.3.5" \
+  -H "User-Agent: BriaSkills/1.3.6" \
   -d '{
     "image": "https://example.com/image.jpg",
     "object_name": "table"
@@ -797,7 +818,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/erase_by_text" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/blend" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.3.5" \
+  -H "User-Agent: BriaSkills/1.3.6" \
   -d '{
     "image": "https://example.com/base.jpg",
     "overlay": "https://example.com/texture.png",
@@ -808,7 +829,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/blend" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/reseason" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.3.5" \
+  -H "User-Agent: BriaSkills/1.3.6" \
   -d '{
     "image": "https://example.com/image.jpg",
     "season": "winter"
@@ -818,7 +839,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/reseason" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/restyle" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.3.5" \
+  -H "User-Agent: BriaSkills/1.3.6" \
   -d '{
     "image": "https://example.com/image.jpg",
     "style": "oil_painting"
@@ -828,7 +849,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/restyle" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/relight" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.3.5" \
+  -H "User-Agent: BriaSkills/1.3.6" \
   -d '{
     "image": "https://example.com/image.jpg",
     "light_type": "sunrise light",
@@ -839,7 +860,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/relight" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/sketch_to_colored_image" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.3.5" \
+  -H "User-Agent: BriaSkills/1.3.6" \
   -d '{
     "image": "https://example.com/sketch.png",
     "prompt": "modern sports car"
@@ -849,7 +870,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/sketch_to_colored_i
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/restore" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.3.5" \
+  -H "User-Agent: BriaSkills/1.3.6" \
   -d '{
     "image": "https://example.com/old-photo.jpg"
   }'
@@ -858,7 +879,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/restore" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/colorize" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.3.5" \
+  -H "User-Agent: BriaSkills/1.3.6" \
   -d '{
     "image": "https://example.com/bw-photo.jpg",
     "color": "contemporary color"
@@ -868,7 +889,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/colorize" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/crop_foreground" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.3.5" \
+  -H "User-Agent: BriaSkills/1.3.6" \
   -d '{
     "image": "https://example.com/image.jpg"
   }'
@@ -877,7 +898,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/crop_foreground" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/blur_background" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.3.5" \
+  -H "User-Agent: BriaSkills/1.3.6" \
   -d '{
     "image": "https://example.com/image.jpg"
   }'
@@ -886,7 +907,7 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/blur_background" \
 curl -X POST "https://engine.prod.bria-api.com/v2/image/edit/erase_foreground" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.3.5" \
+  -H "User-Agent: BriaSkills/1.3.6" \
   -d '{
     "image": "https://example.com/image.jpg"
   }'

--- a/kiro/bria-ai/steering/bria-client-python.py
+++ b/kiro/bria-ai/steering/bria-client-python.py
@@ -25,7 +25,7 @@ import base64
 import time
 import mimetypes
 import requests
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List, Union
 
 
 class BriaClient:
@@ -108,7 +108,7 @@ class BriaClient:
         return {
             "api_token": self.api_key,
             "Content-Type": "application/json",
-            "User-Agent": "BriaSkills/1.3.5",
+            "User-Agent": "BriaSkills/1.3.6",
         }
 
     def _request(self, endpoint: str, data: Dict, wait: bool = True) -> Dict[str, Any]:
@@ -513,7 +513,7 @@ class BriaClient:
 
     def edit_image(
         self,
-        image_url: str,
+        image_url: Union[str, List[str]],
         instruction: str,
         mask_url: Optional[str] = None,
         wait: bool = True,
@@ -522,16 +522,21 @@ class BriaClient:
         Edit an image using natural language instructions.
 
         Args:
-            image_url: Source image URL or base64 data URL
-            instruction: Edit instruction (e.g., "change the mug to red")
-            mask_url: Optional mask for localized editing (white=edit, black=keep)
+            image_url: Source image URL or base64 data URL, or a list of 2-4 of them to
+                combine. The list is ordered, and the instruction addresses each entry by
+                position: the first is "image 1", the second "image 2", and so on.
+            instruction: Edit instruction (e.g., "change the mug to red", or
+                "dress the man in image 1 in the santa outfit from image 2")
+            mask_url: Optional mask for localized editing (white=edit, black=keep).
+                Supported for single-image edits only.
             wait: Wait for completion
 
         Returns:
             Dict with edited image_url
         """
+        images = [image_url] if isinstance(image_url, str) else list(image_url)
         data = {
-            "images": [self._resolve_image(image_url, as_data_url=True)],
+            "images": [self._resolve_image(image, as_data_url=True) for image in images],
             "instruction": instruction,
         }
         if mask_url:

--- a/kiro/bria-ai/steering/bria-client-typescript.ts
+++ b/kiro/bria-ai/steering/bria-client-typescript.ts
@@ -122,7 +122,7 @@ export class BriaClient {
     return {
       api_token: this.apiKey,
       "Content-Type": "application/json",
-      "User-Agent": "BriaSkills/1.3.5",
+      "User-Agent": "BriaSkills/1.3.6",
     };
   }
 
@@ -521,20 +521,25 @@ export class BriaClient {
 
   /**
    * Edit an image using natural language instructions.
-   * @param imageUrl - Source image URL or base64 data URL
-   * @param instruction - Edit instruction (e.g., "change the mug to red")
-   * @param maskUrl - Optional mask for localized editing (white=edit, black=keep)
+   * @param imageUrl - Source image URL or base64 data URL, or an array of 2-4 of them to
+   *                   combine. The array is ordered, and the instruction addresses each entry
+   *                   by position: the first is "image 1", the second "image 2", and so on.
+   * @param instruction - Edit instruction (e.g., "change the mug to red", or
+   *                      "dress the man in image 1 in the santa outfit from image 2")
+   * @param maskUrl - Optional mask for localized editing (white=edit, black=keep).
+   *                  Supported for single-image edits only.
    * @param wait - Wait for completion
    * @returns Response with edited image_url
    */
   async editImage(
-    imageUrl: string,
+    imageUrl: string | string[],
     instruction: string,
     maskUrl?: string,
     wait = true
   ): Promise<BriaResponse> {
+    const images = Array.isArray(imageUrl) ? imageUrl : [imageUrl];
     const data: Record<string, unknown> = {
-      images: [this.resolveImage(imageUrl, true)],
+      images: images.map((image) => this.resolveImage(image, true)),
       instruction,
     };
     if (maskUrl) data.mask = this.resolveImage(maskUrl, true);

--- a/kiro/bria-ai/steering/workflows.md
+++ b/kiro/bria-ai/steering/workflows.md
@@ -14,7 +14,7 @@ async def generate_image(session, api_key, prompt, aspect_ratio="1:1"):
     """Launch a single generation request."""
     async with session.post(
         "https://engine.prod.bria-api.com/v2/image/generate",
-        headers={"api_token": api_key, "Content-Type": "application/json", "User-Agent": "BriaSkills/1.3.5"},
+        headers={"api_token": api_key, "Content-Type": "application/json", "User-Agent": "BriaSkills/1.3.6"},
         json={"prompt": prompt, "aspect_ratio": aspect_ratio}
     ) as resp:
         return await resp.json()
@@ -22,7 +22,7 @@ async def generate_image(session, api_key, prompt, aspect_ratio="1:1"):
 async def poll_status(session, api_key, status_url, timeout=120):
     """Poll until complete or failed."""
     for _ in range(timeout // 2):
-        async with session.get(status_url, headers={"api_token": api_key, "User-Agent": "BriaSkills/1.3.5"}) as resp:
+        async with session.get(status_url, headers={"api_token": api_key, "User-Agent": "BriaSkills/1.3.6"}) as resp:
             data = await resp.json()
             if data["status"] == "COMPLETED":
                 return data["result"]["image_url"]
@@ -109,14 +109,14 @@ async function generateBatch(
       // Launch request
       const res = await fetch("https://engine.prod.bria-api.com/v2/image/generate", {
         method: "POST",
-        headers: { "api_token": apiKey, "Content-Type": "application/json", "User-Agent": "BriaSkills/1.3.5" },
+        headers: { "api_token": apiKey, "Content-Type": "application/json", "User-Agent": "BriaSkills/1.3.6" },
         body: JSON.stringify({ prompt, aspect_ratio: aspectRatio })
       });
       const { status_url } = (await res.json()) as BriaResponse;
 
       // Poll for result
       for (let i = 0; i < 60; i++) {
-        const statusRes = await fetch(status_url, { headers: { "api_token": apiKey, "User-Agent": "BriaSkills/1.3.5" } });
+        const statusRes = await fetch(status_url, { headers: { "api_token": apiKey, "User-Agent": "BriaSkills/1.3.6" } });
         const data = (await statusRes.json()) as BriaStatusResponse;
         if (data.status === "COMPLETED") return data.result!.image_url;
         if (data.status === "FAILED") throw new Error(data.error || "Generation failed");
@@ -174,7 +174,7 @@ async def product_pipeline(api_key, product_descriptions, scene_prompt):
             # Step 2: Remove background
             async with session.post(
                 "https://engine.prod.bria-api.com/v2/image/edit/remove_background",
-                headers={"api_token": api_key, "Content-Type": "application/json", "User-Agent": "BriaSkills/1.3.5"},
+                headers={"api_token": api_key, "Content-Type": "application/json", "User-Agent": "BriaSkills/1.3.6"},
                 json={"image": product_url}
             ) as resp:
                 rmbg_result = await resp.json()
@@ -183,7 +183,7 @@ async def product_pipeline(api_key, product_descriptions, scene_prompt):
             # Step 3: Place in lifestyle scene
             async with session.post(
                 "https://engine.prod.bria-api.com/v2/image/edit/lifestyle_shot_by_text",
-                headers={"api_token": api_key, "Content-Type": "application/json", "User-Agent": "BriaSkills/1.3.5"},
+                headers={"api_token": api_key, "Content-Type": "application/json", "User-Agent": "BriaSkills/1.3.6"},
                 json={"image": transparent_url, "prompt": scene_prompt}
             ) as resp:
                 lifestyle_result = await resp.json()

--- a/kiro/image-utils/POWER.md
+++ b/kiro/image-utils/POWER.md
@@ -305,6 +305,6 @@ See `steering/image-utils-python.py` for complete implementation with docstrings
 
 **Original Work:** This power is converted from the [bria-skill](https://github.com/bria-ai/bria-skill) Claude Code skill by Bria AI.
 
-**Source Version:** Based on version 1.3.5.
+**Source Version:** Based on version 1.3.6.
 
 **Update Frequency:** This power will be updated periodically.

--- a/kiro/image-utils/steering/image-utils-python.py
+++ b/kiro/image-utils/steering/image-utils-python.py
@@ -101,7 +101,7 @@ class ImageUtils:
             PIL Image object
         """
         response = requests.get(
-            url, timeout=timeout, headers={"User-Agent": "BriaSkills/1.3.5"}
+            url, timeout=timeout, headers={"User-Agent": "BriaSkills/1.3.6"}
         )
         response.raise_for_status()
         return Image.open(io.BytesIO(response.content))

--- a/kiro/vgl/POWER.md
+++ b/kiro/vgl/POWER.md
@@ -264,7 +264,7 @@ Only change what the edit strictly requires.
 curl -X POST "https://engine.prod.bria-api.com/v2/image/generate" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.3.5" \
+  -H "User-Agent: BriaSkills/1.3.6" \
   -d '{
     "structured_prompt": "{\"short_description\": \"...\", ...}",
     "prompt": "Generate this scene",
@@ -291,6 +291,6 @@ curl -X POST "https://engine.prod.bria-api.com/v2/image/generate" \
 
 **Original Work:** This power is converted from the [bria-skill](https://github.com/bria-ai/bria-skill) Claude Code skill by Bria AI.
 
-**Source Version:** Based on version 1.3.5.
+**Source Version:** Based on version 1.3.6.
 
 **Update Frequency:** This power will be updated periodically.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bria-skills",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bria-skills",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "license": "MIT",
       "bin": {
         "bria-skills": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bria-skills",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Official Bria AI skills for Claude Code - image generation, editing, background removal, VGL structured prompts, and image utilities",
   "bin": {
     "bria-skills": "bin/cli.js"

--- a/preambles/image-input-handling.md
+++ b/preambles/image-input-handling.md
@@ -29,4 +29,9 @@ RESULT_URL=$(bria_call /v2/image/edit/replace_background "https://example.com/im
 
 # Edit image (uses images array)
 RESULT_URL=$(bria_call /v2/image/edit "/path/to/image.png" --key images '"instruction": "make it warmer"')
+
+# Edit with reference images — each --image adds the next one, in order ("image 1", "image 2", …)
+RESULT_URL=$(bria_call /v2/image/edit "https://example.com/man.jpg" --key images \
+  --image "https://example.com/santa.png" \
+  '"instruction": "dress the man in image 1 in the santa outfit from image 2"')
 ```

--- a/skills/bria-ai/SKILL.md
+++ b/skills/bria-ai/SKILL.md
@@ -235,7 +235,9 @@ position in the instruction: *"dress the man in image 1 in the santa outfit from
 each reference contributes ("the background of image 3"), in plain prose. A single-image edit needs
 no positional wording: *"change the mug color to red"*.
 
-**Generation options:** Aspect ratios `1:1`, `16:9`, `4:3`, `9:16`, `3:4`. Resolution `1MP` (default) or `4MP` (more detail, +30s). Pass `"sync": true` for single images.
+**Generation options:** Aspect ratios `1:1`, `16:9`, `4:3`, `9:16`, `3:4`. Resolution `1MP` (default) or `4MP` (more detail, +30s). Pass `"sync": true` for a single generated image. Editing endpoints are the other way round —
+they answer with a `status_url` you poll, and `"sync": true` on an edit fails with a gateway
+timeout.
 
 > **Advanced**: For precise control over generation, use the **vgl** skill for structured VGL JSON prompts instead of natural language.
 

--- a/skills/bria-ai/SKILL.md
+++ b/skills/bria-ai/SKILL.md
@@ -4,7 +4,7 @@ description: Image generation, photo editing, background removal — transparent
 license: MIT
 metadata:
   author: Bria AI
-  version: "1.3.5"
+  version: "1.3.6"
 ---
 
 # Bria — AI Image Generation, Editing & Background Removal
@@ -150,6 +150,7 @@ Interpret the output:
 |------|------------|----------|
 | Generate images from text | FIBO Generate | Hero images, product shots, illustrations, social media images, banners |
 | Edit images by text instruction | FIBO-Edit | Change colors, modify objects, transform scenes |
+| Combine 2–4 images in one edit | FIBO-Edit multi-reference | Put the outfit, product, logo, style, or background of one image into another |
 | Edit image region with mask | GenFill/Erase | Precise inpainting, add/replace specific regions |
 | Add/Replace/Remove objects | Text-based editing | Add vase, replace apple with pear, remove table |
 | Remove background (transparent PNG) | RMBG-2.0 | Extract subjects for overlays, logos, cutouts |
@@ -193,6 +194,11 @@ RESULT=$(bria_call /v2/image/edit/replace_background "https://example.com/img.jp
 # Edit image (uses images array — pass --key images)
 RESULT=$(bria_call /v2/image/edit "/path/to/image.png" --key images '"instruction": "make it look warmer"')
 
+# Edit with reference images — each --image adds the next one, in order
+RESULT=$(bria_call /v2/image/edit "https://example.com/man.jpg" --key images \
+  --image "https://example.com/santa.png" \
+  '"instruction": "dress the man in image 1 in the santa outfit from image 2"')
+
 # Upscale (use `desired_increase`, range 2-4. Add `"preserve_alpha": true` for transparent inputs)
 RESULT=$(bria_call /v2/image/edit/increase_resolution "https://example.com/img.jpg" '"desired_increase": 4')
 
@@ -217,8 +223,17 @@ echo "$RESULT"
 **Calling convention:** `bria_call <endpoint> <image_or_empty> [--key <json_key>] [extra JSON fields...]`
 - Pass a URL, local file path, or `""` (empty) for endpoints without image input
 - Use `--key images` when the endpoint expects an `images` array instead of `image`
+- Add `--image <url_or_path>` once per extra reference image (`--key images`, up to 4 in total).
+  Order is preserved: the positional image is "image 1", the first `--image` is "image 2", …
 - Extra JSON fields are appended as key-value pairs: `'"key": "value"'`
 - Returns the result image URL on success, or prints an error to stderr
+
+**Editing with several images (2–4):** reach for a second image when the look the user wants
+already exists as a picture — a specific outfit, product, logo, or scene — instead of something you
+can describe in words. Put the image being edited first, references after it, and address them by
+position in the instruction: *"dress the man in image 1 in the santa outfit from image 2"*. Say what
+each reference contributes ("the background of image 3"), in plain prose. A single-image edit needs
+no positional wording: *"change the mug color to red"*.
 
 **Generation options:** Aspect ratios `1:1`, `16:9`, `4:3`, `9:16`, `3:4`. Resolution `1MP` (default) or `4MP` (more detail, +30s). Pass `"sync": true` for single images.
 

--- a/skills/bria-ai/references/api-endpoints.md
+++ b/skills/bria-ai/references/api-endpoints.md
@@ -157,8 +157,12 @@ position — the first is "image 1", the second "image 2", and so on:
   just that it exists.
 - Plain prose, plain words — "image 1", "image 2". No brackets, tags, or markup.
 
+This endpoint is asynchronous: it answers with `request_id` and `status_url`, which you poll. Do
+not send `"sync": true` here — an instruction edit takes longer than a single response is allowed to
+take, so a synchronous request fails with a gateway timeout even though the job itself is fine.
+
 **Constraints** — each returns 422 with a readable message:
-- More than 4 images.
+- More than 4 images. Trim the set before sending; the request is refused, not truncated.
 - A `mask` together with 2 or more images (masked edits are single-image only).
 - 2 or more images together with a tailored `model_id` or `model_version: FIBO_BBQ` — both of those
   run on the single-reference model.

--- a/skills/bria-ai/references/api-endpoints.md
+++ b/skills/bria-ai/references/api-endpoints.md
@@ -11,7 +11,7 @@ Content-Type: application/json
 User-Agent: BriaSkills/<version>
 ```
 
-> **Required:** Always include the `User-Agent: BriaSkills/<version>` header (where `<version>` is the current skill version from `package.json`, e.g. `BriaSkills/1.3.5`) in every API call, including status polling requests.
+> **Required:** Always include the `User-Agent: BriaSkills/<version>` header (where `<version>` is the current skill version from `package.json`, e.g. `BriaSkills/1.3.6`) in every API call, including status polling requests.
 
 ---
 
@@ -120,7 +120,9 @@ Remove background from image. Returns PNG with transparency.
 
 ### POST /v2/image/edit
 
-Edit an image using natural language instructions. No mask required.
+Edit an image with a natural language instruction — no mask required. Send one image to change it,
+or 2–4 images to combine them: the subject from one with an outfit, product, style, or background
+from another.
 
 **Request:**
 ```json
@@ -130,12 +132,53 @@ Edit an image using natural language instructions. No mask required.
 }
 ```
 
+**Multi-reference request.** `images` is ordered, and the instruction addresses each entry by its
+position — the first is "image 1", the second "image 2", and so on:
+```json
+{
+  "images": ["https://man-image-url", "https://santa-outfit-image-url"],
+  "instruction": "dress the man in image 1 in the santa outfit from image 2",
+  "seed": 1234
+}
+```
+
 **Parameters:**
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `images` | array | required | Array of image URLs or base64 data URLs |
-| `instruction` | string | required | Edit instruction in natural language |
+| `images` | array | required | 1–4 image URLs or base64 data URLs. **Order matters** — the instruction refers to them as "image 1", "image 2", … in the order they are sent |
+| `instruction` | string | required | Edit instruction in natural language. Refer to additional images by position |
+| `seed` | int | random | For reproducibility — the same images, instruction and seed reproduce the same result |
+| `aspect_ratio` | string | - | Output ratio: "1:1", "4:3", "16:9", "3:4", "9:16". Honored with 2+ images; with a single image the output follows that image and the response `warning` says so. Omit it to follow the first image |
+| `model_version` | string | - | Deprecated and ignored — the service picks the edit model from the request contents. A value that is sent comes back with a notice in `warning`; omit it |
+
+**Writing a multi-reference instruction:**
+- Put the image being edited first and the references after it.
+- Say what each reference contributes ("the outfit from image 2", "the background of image 3"), not
+  just that it exists.
+- Plain prose, plain words — "image 1", "image 2". No brackets, tags, or markup.
+
+**Constraints** — each returns 422 with a readable message:
+- More than 4 images.
+- A `mask` together with 2 or more images (masked edits are single-image only).
+- 2 or more images together with a tailored `model_id` or `model_version: FIBO_BBQ` — both of those
+  run on the single-reference model.
+
+**Completed Result:**
+```json
+{
+  "status": "COMPLETED",
+  "result": {
+    "image_url": "https://...",
+    "seed": 1234,
+    "warning": null
+  }
+}
+```
+
+`warning` is set when a parameter was accepted but not honored — `aspect_ratio` on a single-image
+request, a supplied `model_version`, or a tuning parameter the serving model does not read. Relay it
+to the user rather than dropping it.
 
 ### POST /v2/image/edit/gen_fill
 
@@ -664,7 +707,7 @@ Check async request status.
 import requests, time
 
 def poll(status_url, api_key, timeout=120):
-    headers = {"api_token": api_key, "User-Agent": "BriaSkills/1.3.5"}
+    headers = {"api_token": api_key, "User-Agent": "BriaSkills/1.3.6"}
     for _ in range(timeout // 2):
         r = requests.get(status_url, headers=headers)
         data = r.json()

--- a/skills/bria-ai/references/api-endpoints.md
+++ b/skills/bria-ai/references/api-endpoints.md
@@ -28,7 +28,6 @@ Generate images from text prompts using FIBO's structured prompt system.
   "aspect_ratio": "1:1",
   "resolution": "1MP",
   "negative_prompt": "string",
-  "num_results": 1,
   "seed": null
 }
 ```
@@ -38,22 +37,22 @@ Generate images from text prompts using FIBO's structured prompt system.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `prompt` | string | required* | Image description (* or use `structured_prompt`) |
-| `aspect_ratio` | string | "1:1" | "1:1", "4:3", "16:9", "3:4", "9:16" |
+| `aspect_ratio` | string | "1:1" | "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9" |
 | `resolution` | string | "1MP" | Output image resolution. "1MP" or "4MP". "4MP" improves image details, especially for photorealism, but increases latency by ~30 seconds. |
 | `negative_prompt` | string | - | What to exclude |
-| `num_results` | int | 1 | Number of images (1-4) |
 | `seed` | int | random | For reproducibility |
 | `structured_prompt` | string | - | JSON from previous generation (for refinement). Use with `prompt` to refine, or alone with `seed` to recreate. |
-| `image_url` | string | - | Reference image (for inspire mode) |
+| `images` | array | - | Reference image for inspire mode: an array holding one image URL or base64 string |
 
-**Input Combination Rules** (mutually exclusive):
+**Input Combinations** — at least one of `prompt`, `images` or `structured_prompt` is required:
 - `prompt` — Generate from text
-- `image_url` — Generate inspired by a reference image
-- `image_url` + `prompt` — Generate inspired by image, guided by text
+- `images` — Generate inspired by a reference image
+- `images` + `prompt` — Generate inspired by image, guided by text
 - `structured_prompt` + `seed` — Recreate a previous image exactly
 - `structured_prompt` + `prompt` + `seed` — Refine a previous image with new instructions
 
-All combinations support `aspect_ratio`, `negative_prompt`, `num_results`, and `seed`.
+All combinations support `aspect_ratio`, `negative_prompt` and `seed`. Note that `"sync": true`
+cannot be combined with `"resolution": "4MP"` — that pairing is rejected.
 
 **Response:**
 ```json
@@ -149,7 +148,7 @@ position — the first is "image 1", the second "image 2", and so on:
 | `images` | array | required | 1–4 image URLs or base64 data URLs. **Order matters** — the instruction refers to them as "image 1", "image 2", … in the order they are sent |
 | `instruction` | string | required | Edit instruction in natural language. Refer to additional images by position |
 | `seed` | int | random | For reproducibility — the same images, instruction and seed reproduce the same result |
-| `aspect_ratio` | string | - | Output ratio: "1:1", "4:3", "16:9", "3:4", "9:16". Honored with 2+ images; with a single image the output follows that image and the response `warning` says so. Omit it to follow the first image |
+| `aspect_ratio` | string | - | Output ratio: "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9". Honored with 2+ images; with a single image the output follows that image and the response `warning` says so. Omit it to follow the first image |
 | `model_version` | string | - | Deprecated and ignored — the service picks the edit model from the request contents. A value that is sent comes back with a notice in `warning`; omit it |
 
 **Writing a multi-reference instruction:**
@@ -171,10 +170,15 @@ position — the first is "image 1", the second "image 2", and so on:
   "result": {
     "image_url": "https://...",
     "seed": 1234,
+    "structured_prompt": "{...}",
     "warning": null
   }
 }
 ```
+
+The result also carries the structured instruction the edit was rendered from — named
+`structured_prompt` on a polled result and `structured_instruction` on an inline `"sync": true`
+response. Read whichever is present.
 
 `warning` is set when a parameter was accepted but not honored — `aspect_ratio` on a single-image
 request, a supplied `model_version`, or a tuning parameter the serving model does not read. Relay it
@@ -190,9 +194,7 @@ Generate content in a masked region (inpainting).
   "image": "https://source-image-url",
   "mask": "https://mask-image-url",
   "prompt": "what to generate",
-  "mask_type": "manual",
-  "negative_prompt": "string",
-  "num_results": 1
+  "mask_type": "manual"
 }
 ```
 
@@ -204,8 +206,6 @@ Generate content in a masked region (inpainting).
 | `mask` | string | required | Mask URL (white=edit, black=keep) |
 | `prompt` | string | required | What to generate in masked area |
 | `mask_type` | string | "manual" | "manual" or "automatic" |
-| `negative_prompt` | string | - | What to avoid |
-| `num_results` | int | 1 | Number of variations |
 
 **Mask Requirements:**
 - White pixels (255) = area to edit
@@ -276,7 +276,7 @@ Expand/outpaint an image to extend its boundaries.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `image` | string | required | Source image URL or base64 string |
-| `aspect_ratio` | string | required | Target ratio: "1:1", "4:3", "16:9", "3:4", "9:16" |
+| `aspect_ratio` | string \| float | - | Target ratio: "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", or a float. Omit it and pass `canvas_size` instead |
 | `prompt` | string | - | Optional - describe content to generate |
 
 ### POST /v2/image/edit/enhance
@@ -308,8 +308,8 @@ Upscale image resolution.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `image` | string | required | Source image URL |
-| `desired_increase` | int | 2 | Upscale factor, range 2–4 |
-| `preserve_alpha` | bool | false | Preserve transparency. Set `true` when input has an alpha channel — the API upscales and recombines the alpha server-side, so you don't need to handle it client-side. |
+| `desired_increase` | int | 2 | Upscale factor: 2 or 4 |
+| `preserve_alpha` | bool | true | Preserve transparency. Set `true` when input has an alpha channel — the API upscales and recombines the alpha server-side, so you don't need to handle it client-side. |
 
 ### POST /v1/product/cutout
 
@@ -387,7 +387,7 @@ Same as `lifestyle_shot_by_text`, but the scene comes from a reference backgroun
 
 Response: `{ "result": [[ "image_url", … ], …] }`.
 
-### POST /image/edit/product/integrate
+### POST /v2/image/edit/product/integrate
 
 Integrate and embed one or more products into a predefined scene at precise user-defined coordinates. The product is automatically matched to the scene's lighting, perspective, and aesthetics. Products are automatically cut out from their background as part of the pipeline.
 
@@ -442,9 +442,12 @@ Integrate and embed one or more products into a predefined scene at precise user
 }
 ```
 
-### POST /v2/image/edit/product_dimensions
+### POST /v2/image/edit/product/generate/dimensions
 
-Render a marketplace-ready dimension image from a product photo: the background is removed automatically, then measurement callout lines + labels are drawn around the product, with an optional title and optional weight/capacity text. Three visual styles. Useful for e-commerce listings (Amazon-style "dimensions" images).
+Render a marketplace-ready dimension image from a product photo. (The older
+`/v2/image/edit/product_dimensions` path still works but is deprecated — use this one.)
+
+How it works: the background is removed automatically, then measurement callout lines + labels are drawn around the product, with an optional title and optional weight/capacity text. Three visual styles. Useful for e-commerce listings (Amazon-style "dimensions" images).
 
 **Request:**
 ```json
@@ -551,8 +554,7 @@ Blend/merge images or apply textures.
 ```json
 {
   "image": "base64-or-url",
-  "overlay": "texture-or-art-url",
-  "instruction": "Place the art on the shirt, keep the art exactly the same"
+  "instruction": "Place the art from this image on the shirt, keep the art exactly the same"
 }
 ```
 
@@ -602,7 +604,7 @@ Modify the lighting setup of an image.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `image` | string | required | Source image URL or base64 |
-| `light_type` | string | required | Lighting preset (see values below) |
+| `light_type` | string | "soft overcast daylight lighting" | Lighting preset (see values below) |
 | `light_direction` | string | required | `front`, `side`, `bottom`, `top-down` |
 
 **Light Types:** `midday`, `blue hour light`, `low-angle sunlight`, `sunrise light`, `spotlight on subject`, `overcast light`, `soft overcast daylight lighting`, `cloud-filtered lighting`, `fog-diffused lighting`, `side lighting`, `moonlight lighting`, `starlight nighttime`, `soft bokeh lighting`, `harsh studio lighting`
@@ -618,8 +620,7 @@ Convert a sketch or line drawing to a photorealistic image.
 **Request:**
 ```json
 {
-  "image": "sketch-base64-or-url",
-  "prompt": "optional description"
+  "image": "sketch-base64-or-url"
 }
 ```
 
@@ -689,7 +690,7 @@ Check async request status.
 **Response:**
 ```json
 {
-  "status": "IN_PROGRESS | COMPLETED | FAILED",
+  "status": "IN_PROGRESS | COMPLETED | ERROR",
   "result": {
     "image_url": "https://..."
   },
@@ -700,7 +701,8 @@ Check async request status.
 **Status Values:**
 - `IN_PROGRESS` - Still processing
 - `COMPLETED` - Success, result available
-- `FAILED` - Error occurred
+- `ERROR` - The request failed (this is the literal value; there is no `FAILED`)
+- `UNKNOWN` - No such request id
 
 **Polling Pattern:**
 ```python
@@ -713,7 +715,7 @@ def poll(status_url, api_key, timeout=120):
         data = r.json()
         if data["status"] == "COMPLETED":
             return data["result"]["image_url"]
-        if data["status"] == "FAILED":
+        if data["status"] in ("ERROR", "UNKNOWN"):
             raise Exception(data.get("error"))
         time.sleep(2)
     raise TimeoutError()

--- a/skills/bria-ai/references/api-endpoints.md
+++ b/skills/bria-ai/references/api-endpoints.md
@@ -148,7 +148,7 @@ position — the first is "image 1", the second "image 2", and so on:
 | `images` | array | required | 1–4 image URLs or base64 data URLs. **Order matters** — the instruction refers to them as "image 1", "image 2", … in the order they are sent |
 | `instruction` | string | required | Edit instruction in natural language. Refer to additional images by position |
 | `seed` | int | random | For reproducibility — the same images, instruction and seed reproduce the same result |
-| `aspect_ratio` | string | - | Output ratio: "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9". Honored with 2+ images; with a single image the output follows that image and the response `warning` says so. Omit it to follow the first image |
+| `aspect_ratio` | string | - | Output ratio: "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9". Honored only with 2 or more images. Do not send it on a single-image request — the output follows that image regardless and the response carries a `warning`; to change one image's ratio, use `/v2/image/edit/expand` |
 | `model_version` | string | - | Deprecated and ignored — the service picks the edit model from the request contents. A value that is sent comes back with a notice in `warning`; omit it |
 
 **Writing a multi-reference instruction:**

--- a/skills/bria-ai/references/code-examples/bria_client.sh
+++ b/skills/bria-ai/references/code-examples/bria_client.sh
@@ -8,20 +8,28 @@
 #   RESULT=$(bria_call /v2/image/edit/remove_background "/path/to/image.png")
 #   RESULT=$(bria_call /v2/image/edit/replace_background "https://example.com/img.jpg" '"prompt":"sunset beach"')
 #   RESULT=$(bria_call /v2/image/edit "/path/to/image.png" --key images '"instruction":"make it red"')
+#   RESULT=$(bria_call /v2/image/edit "https://example.com/man.jpg" --key images \
+#     --image "https://example.com/santa.png" \
+#     '"instruction":"dress the man in image 1 in the santa outfit from image 2"')
+#
+# Each extra --image adds the next reference image, in order: the positional image is "image 1",
+# the first --image is "image 2", and so on. Only the images array (--key images) takes references.
 #
 # BRIA_API_KEY is auto-loaded from ~/.bria/credentials if not already set.
 
 BRIA_API_BASE="${BRIA_API_BASE:-https://engine.prod.bria-api.com}"
-BRIA_USER_AGENT="BriaSkills/1.3.5"
+BRIA_USER_AGENT="BriaSkills/1.3.6"
 
 bria_call() {
-  local endpoint image key extra payload result http_code body url status_url poll i
+  local endpoint image key extra payload result http_code body url status_url poll i img
+  local references=()
   endpoint="$1"; image="$2"; shift 2
 
   key="image"; extra=""
   while [ $# -gt 0 ]; do
     case "$1" in
       --key) key="$2"; shift 2 ;;
+      --image) references+=("$2"); shift 2 ;;
       *) extra="${extra:+$extra, }$1"; shift ;;
     esac
   done
@@ -36,25 +44,32 @@ bria_call() {
 
   if [ -z "$image" ]; then
     printf '{' > "$payload"
+  elif [ "$key" = "images" ]; then
+    # Written one entry at a time, in argument order: the array position is how the instruction
+    # addresses each image ("image 1", "image 2"), so nothing here may reorder them.
+    printf '{"images": [' > "$payload"
+    i=0
+    # ${arr[@]+"${arr[@]}"} expands to nothing for an empty array instead of failing under `set -u`.
+    for img in "$image" ${references[@]+"${references[@]}"}; do
+      [ "$i" -gt 0 ] && printf ', ' >> "$payload"
+      if printf '%s' "$img" | grep -qE '^https?://'; then
+        printf '"%s"' "$img" >> "$payload"
+      else
+        [ ! -f "$img" ] && { echo "ERROR: File not found: $img" >&2; return 1; }
+        printf '"' >> "$payload"
+        base64 < "$img" | tr -d '\n' >> "$payload"
+        printf '"' >> "$payload"
+      fi
+      i=$((i + 1))
+    done
+    printf ']' >> "$payload"
   elif printf '%s' "$image" | grep -qE '^https?://'; then
-    if [ "$key" = "images" ]; then
-      printf '{"images": ["%s"]' "$image" > "$payload"
-    else
-      printf '{"%s": "%s"' "$key" "$image" > "$payload"
-    fi
+    printf '{"%s": "%s"' "$key" "$image" > "$payload"
   else
     [ ! -f "$image" ] && { echo "ERROR: File not found: $image" >&2; return 1; }
-    if [ "$key" = "images" ]; then
-      printf '{"images": ["' > "$payload"
-    else
-      printf '{"%s": "' "$key" > "$payload"
-    fi
+    printf '{"%s": "' "$key" > "$payload"
     base64 < "$image" | tr -d '\n' >> "$payload"
-    if [ "$key" = "images" ]; then
-      printf '"]' >> "$payload"
-    else
-      printf '"' >> "$payload"
-    fi
+    printf '"' >> "$payload"
   fi
 
   if [ -n "$extra" ]; then

--- a/skills/bria-ai/references/code-examples/build_catalog.py
+++ b/skills/bria-ai/references/code-examples/build_catalog.py
@@ -45,7 +45,7 @@ def api_key():
 KEY = None
 def H():
     return {"api_token": KEY, "Content-Type": "application/json",
-            "User-Agent": "BriaSkills/1.3.5"}
+            "User-Agent": "BriaSkills/1.3.6"}
 
 
 def post(path, payload, tries=3):

--- a/skills/ecommerce/SKILL.md
+++ b/skills/ecommerce/SKILL.md
@@ -4,7 +4,7 @@ description: End-to-end e-commerce product catalog generation — turn a folder 
 license: MIT
 metadata:
   author: Bria AI
-  version: "1.3.5"
+  version: "1.3.6"
 ---
 
 # Bria E-commerce — Product Catalog Builder

--- a/skills/image-utils/SKILL.md
+++ b/skills/image-utils/SKILL.md
@@ -4,7 +4,7 @@ description: Classic image manipulation with Python Pillow - resize, crop, compo
 license: MIT
 metadata:
   author: Bria AI
-  version: "1.3.5"
+  version: "1.3.6"
 ---
 
 # Image Utilities

--- a/skills/image-utils/references/code-examples/image_utils.py
+++ b/skills/image-utils/references/code-examples/image_utils.py
@@ -101,7 +101,7 @@ class ImageUtils:
             PIL Image object
         """
         response = requests.get(
-            url, timeout=timeout, headers={"User-Agent": "BriaSkills/1.3.5"}
+            url, timeout=timeout, headers={"User-Agent": "BriaSkills/1.3.6"}
         )
         response.raise_for_status()
         return Image.open(io.BytesIO(response.content))

--- a/skills/remove-background/SKILL.md
+++ b/skills/remove-background/SKILL.md
@@ -4,7 +4,7 @@ description: Remove backgrounds from images — background removal API for trans
 license: MIT
 metadata:
   author: Bria AI
-  version: "1.3.5"
+  version: "1.3.6"
 ---
 
 # Remove Background — Transparent PNGs & Cutouts with RMBG 2.0

--- a/skills/remove-background/references/api-endpoints.md
+++ b/skills/remove-background/references/api-endpoints.md
@@ -8,10 +8,10 @@
 ```
 api_token: YOUR_BRIA_API_KEY
 Content-Type: application/json
-User-Agent: BriaSkills/1.3.5
+User-Agent: BriaSkills/1.3.6
 ```
 
-> **Required:** Always include the `User-Agent: BriaSkills/1.3.5` header in every API call, including status polling requests.
+> **Required:** Always include the `User-Agent: BriaSkills/1.3.6` header in every API call, including status polling requests.
 
 ---
 

--- a/skills/remove-background/references/code-examples/bria_client.sh
+++ b/skills/remove-background/references/code-examples/bria_client.sh
@@ -12,7 +12,7 @@
 # BRIA_API_KEY is auto-loaded from ~/.bria/credentials if not already set.
 
 BRIA_API_BASE="${BRIA_API_BASE:-https://engine.prod.bria-api.com}"
-BRIA_USER_AGENT="BriaSkills/1.3.5"
+BRIA_USER_AGENT="BriaSkills/1.3.6"
 
 bria_call() {
   local endpoint image key extra payload result http_code body url status_url poll i

--- a/skills/vgl/SKILL.md
+++ b/skills/vgl/SKILL.md
@@ -4,7 +4,7 @@ description: Maximum control over AI image generation — write structured VGL (
 license: MIT
 metadata:
   author: Bria AI
-  version: "1.3.5"
+  version: "1.3.6"
 ---
 
 # Bria VGL — Full Control Over Image Generation
@@ -266,7 +266,7 @@ Only change what the edit strictly requires.
 curl -X POST "https://engine.prod.bria-api.com/v2/image/generate" \
   -H "api_token: $BRIA_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "User-Agent: BriaSkills/1.3.5" \
+  -H "User-Agent: BriaSkills/1.3.6" \
   -d '{
     "structured_prompt": "{\"short_description\": \"...\", ...}",
     "prompt": "Generate this scene",

--- a/skills/video-remove-background/SKILL.md
+++ b/skills/video-remove-background/SKILL.md
@@ -4,7 +4,7 @@ description: Remove backgrounds from videos — video background removal API for
 license: MIT
 metadata:
   author: Bria AI
-  version: "1.3.5"
+  version: "1.3.6"
 ---
 
 # Video Remove Background — Transparent Videos & Alpha-Channel Clips

--- a/skills/video-remove-background/references/api-endpoints.md
+++ b/skills/video-remove-background/references/api-endpoints.md
@@ -8,10 +8,10 @@
 ```
 api_token: YOUR_BRIA_API_KEY
 Content-Type: application/json
-User-Agent: BriaSkills/1.3.5
+User-Agent: BriaSkills/1.3.6
 ```
 
-> **Required:** Always include the `User-Agent: BriaSkills/1.3.5` header in every API call, including status polling requests.
+> **Required:** Always include the `User-Agent: BriaSkills/1.3.6` header in every API call, including status polling requests.
 
 ---
 

--- a/skills/video-remove-background/references/code-examples/bria_video_client.sh
+++ b/skills/video-remove-background/references/code-examples/bria_video_client.sh
@@ -12,7 +12,7 @@
 # BRIA_API_KEY is auto-loaded from ~/.bria/credentials if not already set.
 
 BRIA_API_BASE="${BRIA_API_BASE:-https://engine.prod.bria-api.com}"
-BRIA_USER_AGENT="BriaSkills/1.3.5"
+BRIA_USER_AGENT="BriaSkills/1.3.6"
 BRIA_POLL_INTERVAL="${BRIA_POLL_INTERVAL:-5}"    # seconds between status polls
 BRIA_POLL_ATTEMPTS="${BRIA_POLL_ATTEMPTS:-120}"  # max polls (default 120 x 5s = 10 min)
 


### PR DESCRIPTION
[BLD-179](https://bria-ai.atlassian.net/browse/BLD-179) — the public skill half. `/v2/image/edit`
now accepts 1–4 reference images, and the order they are sent in is how the instruction addresses
them. Released as 1.3.6.


## Where this code actually runs

- Someone with the Bria skill installed in Claude Code (npm `bria-skills`, or the plugin
  marketplace) says "put this product into that kitchen photo" or "dress him in the outfit from
  this picture". The agent reads `SKILL.md` and `references/api-endpoints.md`, learns that `images`
  takes up to four entries and that the instruction refers to them as "image 1" and "image 2", and
  calls `bria_call /v2/image/edit "<first>" --key images --image "<second>" '"instruction": …'`.
- The same journey on the other two shipping surfaces: the kiro power (`kiro/bria-ai/POWER.md` plus
  its python, typescript and bash clients) and the OpenClaw plugin
  (`@galbria/bria-ai-openclaw`), whose docs and shell client get the same capability.
- Single-image editing — by far the common case today — is unchanged for every one of those users:
  the payload `bria_call` builds for one image is byte-identical to 1.3.5's.
- Verified against int on 2026-08-23 with the patched client: `remove_background` and a single-image
  `/v2/image/edit` both returned images, a two-image call reached the API and returned the
  documented pre-rollout 422, and the old and new clients were payload-diffed across four shapes
  (URL, local file, plain `image` key, no image) with identical bytes. `skills-ref validate` passes.

## What changed

- `references/api-endpoints.md`: the `POST /v2/image/edit` section is rewritten around the ordered
  `images` array — a multi-reference request example, the parameters that change agent behaviour
  (`seed`, `negative_prompt`, `aspect_ratio` with its single-image caveat, `model_version` as one
  advanced "omit it" line), how to word a multi-reference instruction, the three 422s, and the
  response `warning` field. Applied to the canonical skill and both variants.
- `SKILL.md` (and `POWER.md`, and the OpenClaw skill and its capabilities reference): a
  multi-reference capability row, a two-image `bria_call` example, the `--image` convention, and a
  short passage on when to reach for a second image and how to word the instruction.
- `references/code-examples/bria_client.sh`: `bria_call` takes a repeatable `--image` flag that
  appends the next reference, in order. The kiro python, typescript and bash clients' edit methods
  accept several images the same way.
- `preambles/image-input-handling.md` documents the multi-image call alongside the single-image one.
- Version 1.3.6 across the packages, plugin manifests, skill front matter and `BRIA_USER_AGENT`.

## Decisions in this change

- **The variant re-sync is its own commit.** `kiro/` and `bria-ai-openclaw/` keep hand-maintained
  copies of `api-endpoints.md`; both had fallen 138 lines behind the canonical file (no
  `/v1/product/*`, no `product_dimensions`, and the pre-rename `scale` and `prompt` parameters).
  They were byte-identical to each other, so the first commit copies the canonical file over both
  and the second applies the multi-reference change once across all three — the alternative was a
  re-sync hidden inside a feature diff.
- **`steps_num` and `guidance_scale` stay undocumented.** They were never documented on this
  endpoint, and multi-reference requests ignore them; documenting them as accepted-but-ignored
  would invite agents to send inert parameters.
- **`model_version` is described only as an advanced "omit it" parameter**, and no example sends
  one, so skill traffic follows the server default and rides the rollout.
- **Instructions are plain prose with 1-based positions** ("image 1", "image 2"), matching the
  pipeline's own convention. The bracketed `<image_N>` form belongs to the internal structured
  prompt layer and stays out of skill copy.

## Release dependency

Multi-image requests are gated on the PostHog flag
[`fibo-edit-1-5-enabled`](https://eu.posthog.com/project/85705/feature_flags/251758), currently
rolled out to the Bria organization only. Everything single-image in 1.3.6 works today; the
multi-reference documentation describes what that flag turns on, so this release wants to go out as
the flag widens beyond Bria.
