### PR TITLE
feat: add style_id param to image/generate

### DIFF
--- a/bria-ai-openclaw/skills/bria-ai/references/api-endpoints.md
+++ b/bria-ai-openclaw/skills/bria-ai/references/api-endpoints.md
@@ -44,7 +44,7 @@ Generate images from text prompts using FIBO's structured prompt system.
 | `negative_prompt` | string | - | What to exclude |
 | `num_results` | int | 1 | Number of images (1-4) |
 | `seed` | int | random | For reproducibility |
-| `style_id` | string | "default" | Named prompt style that shapes how the prompt becomes the image (e.g. more cinematic or illustrative results). Optional — omit for the standard style. Only `default` is available by default; additional styles are account-specific. Format: lowercase letters, digits, `-`, `_`. |
+| `style_id` | string | "default" | Named prompt style that shapes how the prompt becomes the image. `"default"` (standard) or `"photoreal"` (tuned for photorealistic results). Optional — omit for the standard style. |
 | `structured_prompt` | string | - | JSON from previous generation (for refinement). Use with `prompt` to refine, or alone with `seed` to recreate. |
 | `image_url` | string | - | Reference image (for inspire mode) |
 

--- a/bria-ai-openclaw/skills/bria-ai/references/api-endpoints.md
+++ b/bria-ai-openclaw/skills/bria-ai/references/api-endpoints.md
@@ -29,7 +29,8 @@ Generate images from text prompts using FIBO's structured prompt system.
   "resolution": "1MP",
   "negative_prompt": "string",
   "num_results": 1,
-  "seed": null
+  "seed": null,
+  "style_id": "default"
 }
 ```
 
@@ -43,6 +44,7 @@ Generate images from text prompts using FIBO's structured prompt system.
 | `negative_prompt` | string | - | What to exclude |
 | `num_results` | int | 1 | Number of images (1-4) |
 | `seed` | int | random | For reproducibility |
+| `style_id` | string | "default" | Named prompt style that shapes how the prompt becomes the image (e.g. more cinematic or illustrative results). Optional — omit for the standard style. Only `default` is available by default; additional styles are account-specific. Format: lowercase letters, digits, `-`, `_`. |
 | `structured_prompt` | string | - | JSON from previous generation (for refinement). Use with `prompt` to refine, or alone with `seed` to recreate. |
 | `image_url` | string | - | Reference image (for inspire mode) |
 
@@ -53,7 +55,7 @@ Generate images from text prompts using FIBO's structured prompt system.
 - `structured_prompt` + `seed` — Recreate a previous image exactly
 - `structured_prompt` + `prompt` + `seed` — Refine a previous image with new instructions
 
-All combinations support `aspect_ratio`, `negative_prompt`, `num_results`, and `seed`.
+All combinations support `aspect_ratio`, `negative_prompt`, `num_results`, `seed`, and `style_id`.
 
 **Response:**
 ```json

--- a/kiro/bria-ai/steering/api-endpoints.md
+++ b/kiro/bria-ai/steering/api-endpoints.md
@@ -44,7 +44,7 @@ Generate images from text prompts using FIBO's structured prompt system.
 | `negative_prompt` | string | - | What to exclude |
 | `num_results` | int | 1 | Number of images (1-4) |
 | `seed` | int | random | For reproducibility |
-| `style_id` | string | "default" | Named prompt style that shapes how the prompt becomes the image (e.g. more cinematic or illustrative results). Optional — omit for the standard style. Only `default` is available by default; additional styles are account-specific. Format: lowercase letters, digits, `-`, `_`. |
+| `style_id` | string | "default" | Named prompt style that shapes how the prompt becomes the image. `"default"` (standard) or `"photoreal"` (tuned for photorealistic results). Optional — omit for the standard style. |
 | `structured_prompt` | string | - | JSON from previous generation (for refinement). Use with `prompt` to refine, or alone with `seed` to recreate. |
 | `image_url` | string | - | Reference image (for inspire mode) |
 

--- a/kiro/bria-ai/steering/api-endpoints.md
+++ b/kiro/bria-ai/steering/api-endpoints.md
@@ -29,7 +29,8 @@ Generate images from text prompts using FIBO's structured prompt system.
   "resolution": "1MP",
   "negative_prompt": "string",
   "num_results": 1,
-  "seed": null
+  "seed": null,
+  "style_id": "default"
 }
 ```
 
@@ -43,6 +44,7 @@ Generate images from text prompts using FIBO's structured prompt system.
 | `negative_prompt` | string | - | What to exclude |
 | `num_results` | int | 1 | Number of images (1-4) |
 | `seed` | int | random | For reproducibility |
+| `style_id` | string | "default" | Named prompt style that shapes how the prompt becomes the image (e.g. more cinematic or illustrative results). Optional — omit for the standard style. Only `default` is available by default; additional styles are account-specific. Format: lowercase letters, digits, `-`, `_`. |
 | `structured_prompt` | string | - | JSON from previous generation (for refinement). Use with `prompt` to refine, or alone with `seed` to recreate. |
 | `image_url` | string | - | Reference image (for inspire mode) |
 
@@ -53,7 +55,7 @@ Generate images from text prompts using FIBO's structured prompt system.
 - `structured_prompt` + `seed` — Recreate a previous image exactly
 - `structured_prompt` + `prompt` + `seed` — Refine a previous image with new instructions
 
-All combinations support `aspect_ratio`, `negative_prompt`, `num_results`, and `seed`.
+All combinations support `aspect_ratio`, `negative_prompt`, `num_results`, `seed`, and `style_id`.
 
 **Response:**
 ```json

--- a/skills/bria-ai/references/api-endpoints.md
+++ b/skills/bria-ai/references/api-endpoints.md
@@ -44,7 +44,7 @@ Generate images from text prompts using FIBO's structured prompt system.
 | `negative_prompt` | string | - | What to exclude |
 | `num_results` | int | 1 | Number of images (1-4) |
 | `seed` | int | random | For reproducibility |
-| `style_id` | string | "default" | Named prompt style that shapes how the prompt becomes the image (e.g. more cinematic or illustrative results). Optional — omit for the standard style. Only `default` is available by default; additional styles are account-specific. Format: lowercase letters, digits, `-`, `_`. |
+| `style_id` | string | "default" | Named prompt style that shapes how the prompt becomes the image. `"default"` (standard) or `"photoreal"` (tuned for photorealistic results). Optional — omit for the standard style. |
 | `structured_prompt` | string | - | JSON from previous generation (for refinement). Use with `prompt` to refine, or alone with `seed` to recreate. |
 | `image_url` | string | - | Reference image (for inspire mode) |
 

--- a/skills/bria-ai/references/api-endpoints.md
+++ b/skills/bria-ai/references/api-endpoints.md
@@ -29,7 +29,8 @@ Generate images from text prompts using FIBO's structured prompt system.
   "resolution": "1MP",
   "negative_prompt": "string",
   "num_results": 1,
-  "seed": null
+  "seed": null,
+  "style_id": "default"
 }
 ```
 
@@ -43,6 +44,7 @@ Generate images from text prompts using FIBO's structured prompt system.
 | `negative_prompt` | string | - | What to exclude |
 | `num_results` | int | 1 | Number of images (1-4) |
 | `seed` | int | random | For reproducibility |
+| `style_id` | string | "default" | Named prompt style that shapes how the prompt becomes the image (e.g. more cinematic or illustrative results). Optional — omit for the standard style. Only `default` is available by default; additional styles are account-specific. Format: lowercase letters, digits, `-`, `_`. |
 | `structured_prompt` | string | - | JSON from previous generation (for refinement). Use with `prompt` to refine, or alone with `seed` to recreate. |
 | `image_url` | string | - | Reference image (for inspire mode) |
 
@@ -53,7 +55,7 @@ Generate images from text prompts using FIBO's structured prompt system.
 - `structured_prompt` + `seed` — Recreate a previous image exactly
 - `structured_prompt` + `prompt` + `seed` — Refine a previous image with new instructions
 
-All combinations support `aspect_ratio`, `negative_prompt`, `num_results`, and `seed`.
+All combinations support `aspect_ratio`, `negative_prompt`, `num_results`, `seed`, and `style_id`.
 
 **Response:**
 ```json


### PR DESCRIPTION
## What

Documents the new optional **`style_id`** parameter on `POST /v2/image/generate` across all three skill distributions:

- `skills/bria-ai/references/api-endpoints.md`
- `bria-ai-openclaw/skills/bria-ai/references/api-endpoints.md`
- `kiro/bria-ai/steering/api-endpoints.md`

Each file gets: the field added to the request JSON example, a parameters-table row, and inclusion in the "all combinations support…" note.

## Parameter spec

| | |
|---|---|
| Type | string, optional |
| Default | `"default"` (the standard style) |
| Meaning | Named prompt style that shapes how the prompt becomes the image |
| Format | lowercase letters, digits, `-`, `_` (max 63) |
| Availability | Only `default` ships bundled; additional styles are account-specific |

Spec verified against the `text_to_image` service (`text_to_image_generation_input.py:61`) and the `vgl` library (`DEFAULT_STYLE_ID = "default"` in `vgl/styles/model/keys.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the optional `style_id` parameter for image generation requests.
  * Added details about default behavior, account-specific styles, supported formats, and availability across input combinations.
  * Updated request examples to include `style_id`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->