### PR TITLE
feat: add ad-delayer skill (BLD-168) [WIP]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,11 +6,11 @@
     "url": "https://bria.ai"
   },
   "metadata": {
-    "description": "Official Bria AI skills — text-to-image generation, image editing, background removal and replacement, object removal, inpainting, outpainting, upscale, restyle, product photography and packshots, batch/bulk generation, VGL structured prompts, and image utilities. Commercially licensed, royalty-free, brand-safe AI image generation and editing API.",
-    "version": "1.3.5",
+    "description": "Official Bria AI skills — text-to-image generation, image editing, background removal and replacement, object removal, inpainting, outpainting, upscale, restyle, product photography and packshots, ad delayering back into editable layers, batch/bulk generation, VGL structured prompts, and image utilities. Commercially licensed, royalty-free, brand-safe AI image generation and editing API.",
+    "version": "1.3.7",
     "repository": "https://github.com/bria-ai/bria-skill",
     "license": "MIT",
-    "keywords": ["image-generation", "ai-images", "bria", "fibo", "rmbg", "background-removal", "background-replacement", "image-editing", "vgl", "product-photography", "packshot", "lifestyle-shot", "visual-assets", "text-to-image", "photo-editing", "transparent-png", "upscale", "outpaint", "inpaint", "object-removal", "restyle", "e-commerce", "marketing", "marketing-visuals", "social-media", "thumbnail", "banner", "hero-image", "ad-creative", "photo-restoration", "style-transfer", "royalty-free", "commercial-license", "brand-safe", "batch-generation", "bulk-generation", "image-variations", "compositing", "image-api", "pipeline", "visual-content-creation", "generate-image", "create-image", "ai-art", "photo-retouching", "image-enhancement", "relight", "reseason", "sketch-to-photo", "colorize", "web-design", "content-creation", "cutout", "product-placement", "scene-generation"]
+    "keywords": ["image-generation", "ai-images", "bria", "fibo", "rmbg", "background-removal", "background-replacement", "image-editing", "vgl", "product-photography", "packshot", "lifestyle-shot", "visual-assets", "text-to-image", "photo-editing", "transparent-png", "upscale", "outpaint", "inpaint", "object-removal", "restyle", "e-commerce", "marketing", "marketing-visuals", "social-media", "thumbnail", "banner", "hero-image", "ad-creative", "photo-restoration", "style-transfer", "royalty-free", "commercial-license", "brand-safe", "batch-generation", "bulk-generation", "image-variations", "compositing", "image-api", "pipeline", "visual-content-creation", "generate-image", "create-image", "ai-art", "photo-retouching", "image-enhancement", "relight", "reseason", "sketch-to-photo", "colorize", "web-design", "content-creation", "cutout", "product-placement", "scene-generation", "ad-delayer", "delayering", "de-layer", "image-to-layers", "layer-extraction", "psd-recovery", "editable-ad", "ad-resizing"]
   },
   "dependencies": [
     {
@@ -90,6 +90,25 @@
       "strict": false,
       "skills": [
         "./skills/video-remove-background"
+      ],
+      "dependencies": [
+        {
+          "type": "env",
+          "name": "BRIA_API_KEY",
+          "description": "Bria AI API key (get one at https://platform.bria.ai/console/account/api-keys)"
+        }
+      ],
+      "author": {
+        "name": "Bria AI"
+      }
+    },
+    {
+      "name": "ad-delayer",
+      "description": "Turn a finished, flat ad image back into editable layers — background, product shot, logo, headline, body copy, and CTA, each as its own asset with position, size, and typography. Dedicated ad delayering skill for recovering a lost PSD or design file, making a shipped creative editable again, resizing or localising an ad, and reading an ad's structure. Powered by Bria's Ad Delayer.",
+      "source": "./skills/ad-delayer",
+      "strict": false,
+      "skills": [
+        "./skills/ad-delayer"
       ],
       "dependencies": [
         {

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ build/
 tests
 bria-ai-workspace
 remove-background-workspace
+ad-delayer-workspace

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Generate, edit, and precisely control images directly from your AI coding agent 
 /plugin install bria-ai@bria-skills
 ```
 
-The marketplace also bundles the `remove-background`, `vgl`, and `image-utils` plugins — install any of them the same way (e.g. `/plugin install remove-background@bria-skills`).
+The marketplace also bundles the `remove-background`, `video-remove-background`, `ad-delayer`, `vgl`, and `image-utils` plugins — install any of them the same way (e.g. `/plugin install ad-delayer@bria-skills`).
 
 **Other agents** (Cursor, Cline, Codex, and [37+ more](https://skills.sh)):
 
@@ -46,6 +46,7 @@ Ask your agent to generate images, remove backgrounds, edit photos, and more. Th
 | **[bria-ai](./skills/bria-ai/SKILL.md)** | Controllable image generation & editing — 18+ capabilities including text-to-image, object-level editing, background removal, upscaling, restyling, relighting, and product photography |
 | **[remove-background](./skills/remove-background/SKILL.md)** | Dedicated background removal — transparent PNGs, cutouts, and foreground extraction powered by RMBG 2.0. Fastest path for background removal tasks |
 | **[vgl](./skills/vgl/SKILL.md)** | Maximum generation control — structured JSON (Visual Generation Language) that explicitly defines objects, lighting, camera, composition, and style for deterministic, reproducible results |
+| **[ad-delayer](./skills/ad-delayer/SKILL.md)** | Flat ads back into editable layers — background, product shot, logo, headline, copy, and CTA recovered as separate assets with position, size, and typography |
 | **[image-utils](./skills/image-utils/SKILL.md)** | Classic image manipulation — resize, crop, composite, watermarks, format conversion with Python Pillow |
 
 ## What You Can Control

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -5,7 +5,7 @@ const path = require("path");
 const os = require("os");
 
 const PACKAGE_NAME = "bria-skills";
-const SKILLS = ["bria-ai", "vgl", "image-utils", "remove-background"];
+const SKILLS = ["bria-ai", "vgl", "image-utils", "remove-background", "video-remove-background", "ad-delayer"];
 
 // Where the skill files live relative to this script
 const packageRoot = path.resolve(__dirname, "..");
@@ -83,6 +83,8 @@ Skills included:
   vgl                Visual Generation Language structured prompts
   image-utils        Classic image manipulation (resize, crop, composite)
   remove-background  Background removal for transparent PNGs and cutouts (RMBG-2.0)
+  video-remove-background  Background removal for video (transparent webm/mkv)
+  ad-delayer         Flat ads back into editable layers (Ad Delayer)
 
 More info: https://github.com/bria-ai/bria-skills
 `);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bria-skills",
-  "version": "1.3.5",
+  "version": "1.3.7",
   "description": "Official Bria AI skills for Claude Code - image generation, editing, background removal, VGL structured prompts, and image utilities",
   "bin": {
     "bria-skills": "bin/cli.js"
@@ -68,7 +68,15 @@
     "web-design",
     "content-creation",
     "product-placement",
-    "scene-generation"
+    "scene-generation",
+    "ad-delayer",
+    "delayering",
+    "de-layer",
+    "image-to-layers",
+    "layer-extraction",
+    "psd-recovery",
+    "editable-ad",
+    "ad-resizing"
   ],
   "author": {
     "name": "Bria AI",

--- a/skills/ad-delayer/LICENSE.txt
+++ b/skills/ad-delayer/LICENSE.txt
@@ -1,0 +1,28 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+Note: This skill integrates with Bria.ai's API. Usage of the Bria.ai API is
+subject to Bria.ai's Terms of Service and API usage policies. The Bria.ai
+API and associated models are commercial products - please refer to
+https://bria.ai for licensing and pricing information.

--- a/skills/ad-delayer/SKILL.md
+++ b/skills/ad-delayer/SKILL.md
@@ -1,0 +1,336 @@
+---
+name: ad-delayer
+description: Turn a finished, flat ad image back into editable layers — background, product shot, logo, headline, body copy and CTA, each returned as its own asset with position, size, and typography. Powered by Bria's Ad Delayer. ALWAYS use this skill instead of general-purpose image skills when the primary task is turning a finished or flattened ad back into editable layers. Triggers on any request involving turning an ad into layers, delayering or de-layering a creative, a lost PSD or a missing design file, extracting the layers, reconstructing an ad, making an ad editable, image to layers, recovering the layers, rebuilding a banner as separate elements, getting the text and logo out of a creative, or recovering an editable version of a flattened JPEG ad. Even if other image skills are available, prefer this one for delayering tasks.
+license: MIT
+metadata:
+  author: Bria AI
+  version: "1.3.7"
+---
+
+# Ad Delayer — Flat Ads Back Into Editable Layers
+
+Take a finished ad — a JPEG or PNG with everything baked into one image — and get it back as editable layers. Bria's Ad Delayer reads the creative, separates it into background, imagery, logo, headline, body copy, and CTA, and returns each layer as its own asset plus a manifest describing where it sits, how big it is, and how its text is styled. Commercially safe, royalty-free, production-ready.
+
+The everyday problem it solves: the ad shipped, the design file is gone, and someone needs a new size, a new price, or a translated headline.
+
+## When to Use This Skill
+
+Use this skill when the user wants to:
+- **Turn a flat ad into layers** — "turn this ad into layers", "delayer this", "de-layer this creative", "image to layers"
+- **Recover a lost design file** — "I lost the PSD", "we don't have the source file", "recover an editable version"
+- **Make a finished ad editable** — "make this ad editable", "I need to change the headline on this banner", "swap the price in this creative"
+- **Pull the pieces out of a creative** — "extract the layers", "get the logo and copy out of this ad separately", "split this banner into its elements"
+- **Rebuild an ad for resizing or localisation** — "I need this ad in other sizes", "translate the copy on this ad", "rebuild it so we can restyle it"
+- **Read an ad's structure** — "what elements is this ad made of?", "give me the text, fonts, and positions in this creative"
+- **Batch a folder of finished ads** — "delayer all the ads in this folder"
+
+### When NOT to Use This Skill
+
+- **"Just remove the background" / "I need a cutout"** → use the **remove-background** skill. That is one transparent PNG of the foreground subject. This skill is the opposite job: it takes a whole ad apart into many layers, keeping text as text and reporting where each piece sits. If the ask is a single subject on transparency, it is not delayering.
+- **Cutting one object out for compositing** → **remove-background** (whole subject) or **bria-ai** (`erase_from_image` for one object)
+- **Generating or editing an image** — new visuals, restyling, inpainting, expanding → **bria-ai**
+- **Resize, crop, watermark, format conversion** on a file you already have → **image-utils**
+- **Building a fresh ad from scratch** (no source creative to take apart) → **bria-ai**
+
+This skill does one thing: **take a finished ad image apart into editable layers**.
+
+---
+
+## Setup — Authentication
+
+Before making any API call, you need a valid Bria access token.
+
+### Step 1: Check for existing credentials
+
+```bash
+if [ -f ~/.bria/credentials ]; then
+  BRIA_ACCESS_TOKEN=$(grep '^access_token=' "$HOME/.bria/credentials" | cut -d= -f2-)
+  BRIA_API_KEY=$(grep '^api_token=' "$HOME/.bria/credentials" | cut -d= -f2-)
+fi
+if [ -z "$BRIA_ACCESS_TOKEN" ]; then
+  echo "NO_CREDENTIALS"
+elif [ -n "$BRIA_API_KEY" ]; then
+  echo "READY"
+else
+  echo "CREDENTIALS_FOUND"
+fi
+```
+
+If the output is `READY`, skip straight to making API calls — no introspection needed.
+If the output is `CREDENTIALS_FOUND`, skip to Step 3.
+If the output is `NO_CREDENTIALS`, proceed to Step 2.
+
+### Step 2: Authenticate via device authorization
+
+Start the device authorization flow:
+
+**2a. Request a device code:**
+
+```bash
+DEVICE_RESPONSE=$(curl -s -X POST "https://engine.prod.bria-api.com/v2/auth/device/authorize" \
+  -H "Content-Type: application/json")
+echo "$DEVICE_RESPONSE"
+```
+
+Parse the response fields:
+- `device_code` — used to poll for the token (keep this, don't show to user)
+- `user_code` — the code the user must enter (e.g. `BRIA-XXXX`)
+- `interval` — seconds between poll attempts
+
+**2b. Show the user a single sign-in link.** Tell them exactly this — nothing more:
+
+> **Connect your Bria account:** [Click here to sign in](https://platform.bria.ai/device/verify?user_code={user_code})
+> Your code is **{user_code}** — it's already filled in.
+
+Do NOT show two links. Do NOT show the raw URL separately. Do NOT use `verification_uri` from the API response. Keep it to one clickable link.
+
+**2c. Poll for the token.** After showing the user the code, immediately start polling. Try up to 60 times with the given interval (default 5 seconds):
+
+```bash
+for i in $(seq 1 60); do
+  TOKEN_RESPONSE=$(curl -s -X POST "https://engine.prod.bria-api.com/v2/auth/token" \
+    -d "grant_type=urn:ietf:params:oauth:grant-type:device_code" \
+    -d "device_code=$DEVICE_CODE")
+  ACCESS_TOKEN=$(printf '%s' "$TOKEN_RESPONSE" | sed -n 's/.*"access_token" *: *"\([^"]*\)".*/\1/p')
+  if [ -n "$ACCESS_TOKEN" ]; then
+    BRIA_ACCESS_TOKEN="$ACCESS_TOKEN"
+    REFRESH_TOKEN=$(printf '%s' "$TOKEN_RESPONSE" | sed -n 's/.*"refresh_token" *: *"\([^"]*\)".*/\1/p')
+    mkdir -p ~/.bria
+    printf 'access_token=%s\nrefresh_token=%s\n' "$BRIA_ACCESS_TOKEN" "$REFRESH_TOKEN" > "$HOME/.bria/credentials"
+    echo "AUTHENTICATED"
+    break
+  fi
+  sleep 5
+done
+```
+
+If the output contains `AUTHENTICATED`, proceed to Step 3. Otherwise the code expired — start over from Step 2a.
+
+**Do not proceed with any API call until authentication is confirmed.**
+
+### Step 3: Verify billing status and resolve API key
+
+Introspect the bearer token to check billing status and obtain the real API key for Bria API calls:
+
+```bash
+INTROSPECT=$(curl -s -X POST "https://engine.prod.bria-api.com/v2/auth/token/introspect" \
+  -d "token=$BRIA_ACCESS_TOKEN")
+BILLING_STATUS=$(printf '%s' "$INTROSPECT" | sed -n 's/.*"billing_status" *: *"\([^"]*\)".*/\1/p')
+if [ "$BILLING_STATUS" = "blocked" ]; then
+  BILLING_MSG=$(printf '%s' "$INTROSPECT" | sed -n 's/.*"billing_message" *: *"\([^"]*\)".*/\1/p')
+  echo "BILLING_ERROR: $BILLING_MSG"
+fi
+ACTIVE=$(printf '%s' "$INTROSPECT" | sed -n 's/.*"active" *: *\([^,}]*\).*/\1/p' | tr -d ' ')
+if [ "$ACTIVE" = "false" ]; then
+  # Clear stale tokens so re-auth starts fresh (credentials file is re-created in Step 2c)
+  printf '' > "$HOME/.bria/credentials"
+  echo "TOKEN_EXPIRED"
+fi
+BRIA_API_KEY=$(printf '%s' "$INTROSPECT" | sed -n 's/.*"api_token" *: *"\([^"]*\)".*/\1/p')
+if [ -n "$BRIA_API_KEY" ]; then
+  grep -v '^api_token=' "$HOME/.bria/credentials" > "$HOME/.bria/credentials.tmp" 2>/dev/null || true
+  printf 'api_token=%s\n' "$BRIA_API_KEY" >> "$HOME/.bria/credentials.tmp"
+  mv "$HOME/.bria/credentials.tmp" "$HOME/.bria/credentials"
+fi
+```
+
+Interpret the output:
+- If it prints `BILLING_ERROR: ...` — relay the message to the user exactly as shown and **stop**. Do not make any API calls.
+- If it prints `TOKEN_EXPIRED` — the session is no longer valid. Tell the user their session expired and restart from Step 2.
+- Otherwise, `BRIA_API_KEY` now contains the real API key and is cached for future calls. Proceed to the next section.
+
+---
+
+## How to Delayer an Ad
+
+Source the helper script at `references/code-examples/bria_delayer_client.sh` (resolve `<SKILL_DIR>` to this skill's own directory), then make one call. It handles the local-file encoding, the JSON, the submit, the polling, and downloading every layer. The API key is auto-loaded from `~/.bria/credentials`.
+
+```bash
+source <SKILL_DIR>/references/code-examples/bria_delayer_client.sh
+
+# A local ad file
+bria_delayer "/path/to/summer-sale.jpg"
+# → saved summer-sale-layers/result.json
+# → saved summer-sale-layers/background_1.png
+# → saved summer-sale-layers/logo_1.png
+# → saved summer-sale-layers/product_1.png
+# → 3 layer image(s) plus result.json in summer-sale-layers
+
+# An ad URL
+bria_delayer "https://example.com/creatives/summer-sale.jpg"
+```
+
+**That's it.** One function call. Delayering is asynchronous and takes **2–3 minutes** for a typical ad — the helper polls for up to 6 minutes and tells the user when it is still working.
+
+### Input
+
+- **Local file path** — encoded and sent with the request. No upload step, no temporary URL to manage.
+- **Image URL** — any publicly accessible, direct link to the image file. Passed straight through.
+
+**One ad per call** — the API takes exactly one image per request. To do several, loop (see Examples).
+
+Supported formats: **PNG, JPEG, WEBP, AVIF, GIF, TIFF, BMP, SVG, PDF**. There is no file-size or dimension limit on delayering today.
+
+### Options
+
+| Option | Values | Default | Notes |
+|--------|--------|---------|-------|
+| `--prompt` | free text | none | Guidance for the extraction. Use it to state something the pixels alone do not settle — "the headline and the sub-headline are separate lines", "the roundel top-right is the brand logo, not part of the product", "keep the price and the currency symbol as one text layer". Not needed for a normal run. |
+| `--effort` | `minimal`, `low`, `medium`, `high` | `medium` | How much reasoning Bria spends reading the ad. Raise it for a dense or unusual creative; lower it for a simple one. |
+| `--out-dir` | path | `<input-stem>-layers` | Where the layers land. |
+
+Two environment variables control the wait: `BRIA_POLL_INTERVAL` (default `10` seconds) and `BRIA_POLL_ATTEMPTS` (default `36`, giving a 6-minute ceiling).
+
+### Output
+
+One folder per input ad, named `<input-stem>-layers/`:
+
+```
+summer-sale-layers/
+├── result.json          # the layer manifest
+├── background_1.png     # one image file per image layer, named by its layer id
+├── logo_1.png
+└── product_1.png
+```
+
+`result.json` is the full description of the ad:
+
+```json
+{
+  "canvas": { "width": 1080, "height": 1350 },
+  "layers": [
+    {
+      "id": "canvas_background",
+      "type": "vector",
+      "subtype": "background",
+      "bbox": { "x": 0, "y": 0, "width": 1080, "height": 1350 },
+      "z_order": 0,
+      "style": { "background_color": "#F4EFE7" }
+    },
+    {
+      "id": "logo_1",
+      "type": "image",
+      "subtype": "logo",
+      "bbox": { "x": 74, "y": 64, "width": 180, "height": 62 },
+      "z_order": 4,
+      "asset_path": "https://.../logo_1.png"
+    },
+    {
+      "id": "primary_copy_1",
+      "type": "text",
+      "subtype": "headline",
+      "bbox": { "x": 74, "y": 320, "width": 640, "height": 210 },
+      "z_order": 5,
+      "text": "Summer Sale\nup to 40% off",
+      "text_style": {
+        "color": "#1B1B1B",
+        "font_family": "Poppins",
+        "font_weight": 700,
+        "font_size_px": 88,
+        "line_height": 1.05,
+        "text_align": "left"
+      }
+    }
+  ],
+  "font_stylesheets": ["https://fonts.googleapis.com/css2?family=Poppins:wght@400;700"]
+}
+```
+
+Layer ids are role slots — `canvas_background`, `background_1`, `logo_1`, `image_1`, `product_1`, `primary_copy_1`, `secondary_copy_1`, `cta_1`, and so on. Filenames come straight from those ids; nothing is renamed or invented. Text layers carry their copy and typography in the manifest rather than as a flat image, which is what makes the headline editable. Only image layers have an `asset_path`, so a text-heavy ad yields fewer files than layers. `z_order` is paint order, back to front.
+
+---
+
+## Examples
+
+### Delayer one ad and read back what it is made of
+
+```bash
+source <SKILL_DIR>/references/code-examples/bria_delayer_client.sh
+bria_delayer "/path/to/creatives/black-friday-1080x1350.jpg"
+cat black-friday-1080x1350-layers/result.json
+```
+
+### Delayer an ad from a URL, with guidance
+
+```bash
+source <SKILL_DIR>/references/code-examples/bria_delayer_client.sh
+bria_delayer "https://example.com/ads/spring-promo.png" \
+  --prompt "the small print at the bottom is one legal text layer; the badge top-left is the brand logo"
+```
+
+### Take extra care on a dense creative
+
+```bash
+source <SKILL_DIR>/references/code-examples/bria_delayer_client.sh
+bria_delayer "/path/to/multi-product-carousel.png" --effort high --out-dir ./carousel-layers
+```
+
+### A very large or unusually complex ad
+
+Big canvases take longer than the 6-minute default. Widen the window rather than re-running:
+
+```bash
+source <SKILL_DIR>/references/code-examples/bria_delayer_client.sh
+BRIA_POLL_ATTEMPTS=90 bria_delayer "/path/to/billboard-6000x3000.png"   # 15-minute ceiling
+```
+
+If it still times out, the helper prints the exact command to resume checking that same job — the run keeps going server-side, so resume it instead of paying for a second run.
+
+### Delayer a folder of finished ads
+
+```bash
+source <SKILL_DIR>/references/code-examples/bria_delayer_client.sh
+for ad in creatives/*.jpg; do
+  [ -f "$ad" ] || continue
+  bria_delayer "$ad" && echo "Done: $ad" || echo "Failed: $ad" >&2
+done
+```
+
+Runs are sequential on purpose: the default limit is 9 delayering submits a minute per account, and each run takes minutes anyway.
+
+---
+
+## How It Works
+
+1. The ad is sent to Bria's delayering endpoint (`POST /v2/ads/image_to_layers`) — a local file is encoded into the request, a URL is passed through
+2. The API accepts the job with HTTP 202 and a `status_url`; the work runs asynchronously
+3. The helper polls that status URL every 10 seconds until the run reaches a terminal state
+4. On completion the response carries a pointer to the layer manifest; the helper fetches it as `result.json`
+5. Every image layer's `asset_path` is downloaded next to the manifest, named after its layer id
+
+## Common Errors
+
+Delayering runs asynchronously, so most failures arrive when the job's status is polled rather than as an immediate rejection. The helper handles all of these — this table is what it tells the user, and what it does next.
+
+Only the `401` / `403` row is an authentication problem. A rejected or unreadable image, a failed run, or a timeout says nothing about the credentials — do not re-run the sign-in step for those, and do not clear `~/.bria/credentials`.
+
+Two rules for handling any of these:
+
+- **The helper already applies the retry policy in the last column. Never re-submit the same ad by hand** — every submit is a billed 2–3 minute run, and a failure the table marks "No" will fail again for the same reason. If the ad looks fine locally and Bria still rejects it, that is worth reporting, not retrying.
+- **Tell the user the cause and the fix, not the mechanics.** Endpoints, tokens, status URLs, poll counts and HTTP codes are not useful to them; the files you produced, or what to change about the ad, are.
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `422` "corrupt or empty" | The image could not be read | Re-export the ad and try again. No retry |
+| `422` "Unsupported image format" | The file is not one of the supported formats | Save the ad as PNG, JPEG, or WEBP. No retry |
+| `422` "could not be fetched" | The URL is not a public, direct link to the image | Attach the file itself instead of a link. No retry |
+| `400` / `422` on a request the skill built | Malformed request | Try once more; if it repeats it is an ad-delayer skill issue. No retry |
+| `401` / `403` | API key missing, invalid, or the account is not permitted | Delete `~/.bria/credentials` and run the authentication step again |
+| `429` | Too many delayering submits in a minute for this account (9 by default) | The helper waits and retries automatically (20s, 40s, 60s) |
+| Job status `ERROR` / `500` | The delayering pipeline failed | The helper retries the ad exactly once, then reports the `request_id` to give Bria support |
+| Job status `UNKNOWN` | Bria keeps job status for about a day; this one has aged out | Run the ad again |
+| Polling timeout | The run is slower than the 6-minute default | The job is still going — the helper prints the command to resume checking it, or raise `BRIA_POLL_ATTEMPTS` |
+
+---
+
+## Additional Resources
+
+- **[API Endpoints Reference](references/api-endpoints.md)** — the real endpoint contract: request fields, the 202/status/result-pointer flow, the manifest schema, error shapes, rate limits
+- **[Shell Client (bria_delayer_client.sh)](references/code-examples/bria_delayer_client.sh)** — `bria_delayer` (one call, end to end) plus `bria_delayer_submit`, `bria_delayer_wait`, and `bria_delayer_download` if the steps are needed separately
+
+## Related Skills
+
+- **remove-background** — One transparent PNG of the foreground subject (RMBG 2.0). Use it for cutouts; use this skill when a whole ad has to come apart
+- **bria-ai** — Full Bria API access: generate images, edit photos, remove objects, upscale, restyle, product photography, and 20+ more endpoints
+- **image-utils** — Local post-processing with Python Pillow: resize, crop, composite the recovered layers back together
+- **vgl** — Structured VGL JSON for deterministic control over new image generation

--- a/skills/ad-delayer/references/api-endpoints.md
+++ b/skills/ad-delayer/references/api-endpoints.md
@@ -1,0 +1,205 @@
+# Ad Delayer API Reference
+
+> This file documents the delayering API **as implemented**, verified 2026-08-24 against the
+> service source. When it drifts, the source of truth is the ads service's own request model
+> (`services/ads/app/parse_api_input.py`), its error mapping (`services/ads/app/errors.py`), and
+> the layer-manifest exporter in Bria's deflatter library — not the product spec. Fields the
+> product spec describes but the API does not emit yet (a symbolic error-code registry, a
+> dimension cap, `schema_version`, per-layer confidence) are deliberately absent below.
+
+## Base URL & Authentication
+
+**Base URL:** `https://engine.prod.bria-api.com`
+
+**Authentication:** include these headers in all requests:
+```
+api_token: YOUR_BRIA_API_KEY
+Content-Type: application/json
+User-Agent: BriaSkills/1.3.7
+```
+
+> **Required:** always include the `User-Agent: BriaSkills/1.3.7` header on every call, including
+> status polls. It is how delayering traffic from this skill is identified server-side.
+
+---
+
+## Delayering
+
+### POST /v2/ads/image_to_layers
+
+Takes one flat ad image apart into layers. Asynchronous: returns HTTP 202 with a `request_id` and
+a `status_url` to poll. A typical ad takes **2–3 minutes**.
+
+Use this path, not `/v2/ads/delayer`. The alias exists in the service code but is not routed by
+the load balancer in either environment, so it is unreachable from the public API.
+
+**Request:**
+```json
+{
+  "attachments": ["https://example.com/ads/summer-sale.jpg"],
+  "prompt": "the badge top-left is the brand logo",
+  "thinking_effort": "medium",
+  "output_format": "json",
+  "sync": false
+}
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `attachments` | array of string | Yes | — | The source ad. **Exactly one** entry: a public direct image URL, raw base64, or a `data:` URI. Two or more entries is a 422 |
+| `prompt` | string | No | — | Natural-language guidance for the extraction |
+| `thinking_effort` | string | No | `medium` | `minimal`, `low`, `medium`, or `high` |
+| `output_format` | string | No | `json` | `json` for the layer manifest, `html` for the reconstructed HTML render of the same run |
+| `sync` | boolean | No | `false` | Send `false` explicitly. `true` holds the connection open for the entire 2–3 minute run — far longer than an HTTP response can wait |
+| `webhook_url` | string | No | — | Delivers the result instead of requiring polling. Ignored when `sync` is `true` |
+
+Unknown fields are rejected (`extra="forbid"`).
+Supported input formats: PNG, JPEG, WEBP, AVIF, GIF, TIFF, BMP, SVG, PDF. There is no file-size
+or dimension limit on this endpoint today.
+
+**Response (HTTP 202):**
+```json
+{
+  "request_id": "3f0b7c2e-...",
+  "status_url": "https://engine.prod.bria-api.com/v2/status/3f0b7c2e-..."
+}
+```
+
+---
+
+## Status Polling
+
+### GET /v2/status/{request_id}
+
+Always HTTP 200; the job's own outcome is in the body. `/v2/status/*` is exempt from rate
+limiting, so polling costs nothing against the submit limit.
+
+**While running:**
+```json
+{ "status": "IN_PROGRESS", "request_id": "3f0b7c2e-..." }
+```
+
+**On success:**
+```json
+{
+  "status": "COMPLETED",
+  "result": {
+    "agent_type": "deflat",
+    "status": "completed",
+    "text": "Constructed a layered ad.",
+    "url": "https://.../deflatter/<run-id>/public/creation/creation.json"
+  },
+  "request_id": "3f0b7c2e-..."
+}
+```
+
+**On failure:**
+```json
+{
+  "status": "ERROR",
+  "error": { "code": 422, "message": "The image URL could not be fetched", "details": "..." },
+  "request_id": "3f0b7c2e-..."
+}
+```
+
+**Status values** (the wire values, which differ from the internal enum names):
+
+| Value | Meaning |
+|-------|---------|
+| `IN_PROGRESS` | Still running — poll again |
+| `COMPLETED` | Done; `result.url` points at the layer manifest |
+| `ERROR` | The run failed; `error` carries the reason |
+| `UNKNOWN` | No record of this request id — either it never existed or its status has aged out (status is retained for about a day) |
+
+`result` also carries two legacy fields that are not worth reading: `agent_type` is always
+`"deflat"`, and `text` is a fixed sentence, not a generated description.
+
+**Polling strategy:** 10-second intervals, up to 36 attempts (a 6-minute ceiling; typical runs
+finish in 2–3 minutes). `bria_delayer_wait` implements this — override with `BRIA_POLL_INTERVAL`
+and `BRIA_POLL_ATTEMPTS`.
+
+---
+
+## The result is a pointer, not the layers
+
+`result.url` is a **link to the layer manifest**, not the manifest itself — delayering is a
+three-hop flow:
+
+1. `POST /v2/ads/image_to_layers` → 202 + `status_url`
+2. `GET {status_url}` until `COMPLETED` → `result.url`
+3. `GET {result.url}` → `creation.json`, the manifest below; then GET each layer's `asset_path`
+
+Manifest and assets are stored without an expiry, and every `asset_path` in the published
+manifest has already been rewritten to a public URL, so a plain GET is enough.
+
+### Layer manifest (`creation.json`)
+
+```json
+{
+  "canvas": { "width": 1080, "height": 1350 },
+  "layers": [ { "id": "...", "type": "...", "subtype": "...", "bbox": {}, "z_order": 0 } ],
+  "font_stylesheets": ["https://fonts.googleapis.com/css2?family=Poppins:wght@400;700"]
+}
+```
+
+Null-valued keys are omitted entirely, so a layer only carries the fields that apply to it.
+
+| Layer field | Type | Present on | Description |
+|-------------|------|-----------|-------------|
+| `id` | string | always | Role slot — `canvas_background`, `background_1`, `logo_1`, `image_1`, `product_1`, `primary_copy_1`, `secondary_copy_1`, `cta_1`, … Falls back to `{subtype}_{index}` when no slot was assigned |
+| `type` | string | always | `image`, `text`, or `vector` |
+| `subtype` | string | always | The semantic role behind the slot (`background`, `logo`, `headline`, `cta`, …) |
+| `bbox` | object | always | `{x, y, width, height}` in canvas pixels, 2 decimal places |
+| `z_order` | int | always | Paint order, back to front. `0` is the synthetic `canvas_background` base fill |
+| `text` | string | text layers, and labelled placeholders | The copy, newlines preserved |
+| `asset_path` | string | image layers only | Public URL of that layer's extracted image |
+| `style` | object | when it has any | Box paint: `background_color`, `background_gradient`, `border_*`, `border_radius_*`, `box_shadow`, `opacity`, `rotation_deg`, `skew_x_deg`, `blend_mode`, `vector_shape` |
+| `text_style` | object | text layers | `color`, `font_family`, `font_weight`, `font_size_px`, `letter_spacing_px`, `line_height`, `text_align`, `align_x`, `align_y`, `uppercase`, `underline`, `italic`, `no_wrap`, `direction`, `text_shadows`, `rotation_deg`, `translate_*_px` |
+| `text_runs` | array | text with mixed styling | Per-run `{text, style}`, where `style` holds only what differs from `text_style` |
+| `image_fit` | object | image layers | `object_fit`, `object_position_x`, `object_position_y` |
+
+Only image layers have an `asset_path`, so a text-heavy ad produces fewer files than layers —
+its copy lives in the manifest as editable text, which is the point of delayering.
+
+---
+
+## Errors
+
+There is no symbolic error-code registry. Every failure is the same shape, with `code` set to the
+HTTP status:
+
+```json
+{ "code": 422, "message": "The image URL could not be fetched", "details": "..." }
+```
+
+**Where it arrives depends on when it happens.** Because the run is asynchronous, only failures
+raised before the job starts come back on the submit; the rest arrive on the status poll inside
+`error`.
+
+| Signal | Where | Message | Retry |
+|--------|-------|---------|-------|
+| `401` | submit | Auth failure | No |
+| `403` | submit | Account not permitted / billing | No |
+| `422` | submit | Request-shape rejection — two or more `attachments`, an unknown field, an invalid `thinking_effort` or `output_format` | No |
+| `429` | submit | Rate limit — 9 submits per minute per account on this endpoint by default (configurable per route and plan; some orgs are exempt) | Backoff |
+| `400` | status poll | "An attachment (reference image URL) is required." | No |
+| `422` | status poll | "The uploaded file appears corrupt or empty" | No |
+| `422` | status poll | "Unsupported image format. Supported formats include: PNG, JPEG, WEBP, AVIF, GIF, TIFF, BMP, SVG, PDF" | No |
+| `422` | status poll | "The image URL could not be fetched" — not a public direct link, or resolves to a non-global address | No |
+| `500` | status poll | Pipeline failure; `details` names the stage that failed | Once |
+
+The 4xx messages above are Bria's validator messages, passed through unchanged.
+
+---
+
+## Related endpoints on the same service
+
+Same request model, same async flow, different output — documented here only so the delayering
+path is not confused with them:
+
+- `POST /v2/ads/extract_objects` — returns just the cut-out foreground objects, with dimensions
+  and file sizes, and no layout or text
+- `POST /v2/ads/image_to_template` — returns a reusable template rather than a faithful
+  reconstruction of this specific ad

--- a/skills/ad-delayer/references/code-examples/bria_delayer_client.sh
+++ b/skills/ad-delayer/references/code-examples/bria_delayer_client.sh
@@ -1,0 +1,258 @@
+#!/bin/bash
+# bria_delayer_client.sh — Self-contained helper for Bria Ad Delayer (flat ad → editable layers).
+# Zero dependencies beyond curl, grep, sed, base64 (standard on macOS/Linux).
+#
+# Usage:
+#   source bria_delayer_client.sh
+#   bria_delayer "/path/to/ad.png"
+#   bria_delayer "https://example.com/ad.jpg" --prompt "the headline is two separate lines"
+#   bria_delayer "/path/to/ad.png" --effort high --out-dir ./my-layers
+#
+#   # or the three steps on their own:
+#   STATUS_URL=$(bria_delayer_submit "/path/to/ad.png")
+#   RESULT_URL=$(bria_delayer_wait "$STATUS_URL")
+#   bria_delayer_download "$RESULT_URL" "/path/to/ad.png"
+#
+# BRIA_API_KEY is auto-loaded from ~/.bria/credentials if not already set.
+
+BRIA_API_BASE="${BRIA_API_BASE:-https://engine.prod.bria-api.com}"
+BRIA_USER_AGENT="BriaSkills/1.3.7"
+BRIA_POLL_INTERVAL="${BRIA_POLL_INTERVAL:-10}"     # seconds between status polls
+BRIA_POLL_ATTEMPTS="${BRIA_POLL_ATTEMPTS:-36}"     # max polls (default 36 x 10s = 6 min)
+BRIA_RETRY_BACKOFF="${BRIA_RETRY_BACKOFF:-20 40 60}"  # rate-limit backoff schedule, in seconds
+
+_bria_load_key() {
+  if [ -z "$BRIA_API_KEY" ] && [ -f "$HOME/.bria/credentials" ]; then
+    BRIA_API_KEY=$(grep '^api_token=' "$HOME/.bria/credentials" | cut -d= -f2-)
+  fi
+  [ -z "$BRIA_API_KEY" ] && { echo "Bria sign-in is missing. Run the skill's authentication step first." >&2; return 1; }
+  return 0
+}
+
+_bria_json_str() {
+  # First string value for a key, tolerating pretty or compact JSON.
+  printf '%s' "$2" | grep -oE "\"$1\" *: *\"[^\"]*\"" | head -1 | sed 's/^[^:]*: *"//; s/"$//'
+}
+
+# Map an API failure onto one cause+action sentence. Raw payloads are never printed.
+# Sets BRIA_DELAYER_RETRYABLE=1 when the retry-once rule applies.
+_bria_report_error() {
+  local code="$1" message="$2"
+  BRIA_DELAYER_RETRYABLE=0
+  case "$message" in
+    *"corrupt or empty"*)
+      echo "The image could not be read — the file may be corrupt or empty. Re-export it and try again." >&2; return ;;
+    *"Unsupported image format"*)
+      echo "That image format is not supported. Save the ad as PNG, JPEG or WEBP and try again." >&2; return ;;
+    *"could not be fetched"*)
+      echo "That image URL could not be fetched — it needs to be a public, direct link to the image file. Attach the file instead." >&2; return ;;
+  esac
+  case "$code" in
+    400|422)
+      echo "Bria rejected the request as invalid. Try once more; if it repeats, report it as an ad-delayer skill issue." >&2 ;;
+    401)
+      echo "Bria sign-in is missing or invalid. Delete ~/.bria/credentials and run the authentication step again." >&2 ;;
+    403)
+      echo "This Bria account is not permitted to run this request — check the plan and billing status at https://platform.bria.ai/pricing" >&2 ;;
+    429)
+      echo "Bria is rate-limiting this account (9 delayering submits a minute by default). Wait a minute and try again." >&2 ;;
+    5*)
+      echo "Delayering failed inside Bria's pipeline." >&2; BRIA_DELAYER_RETRYABLE=1 ;;
+    *)
+      echo "Delayering failed (Bria returned status $code)." >&2; BRIA_DELAYER_RETRYABLE=1 ;;
+  esac
+}
+
+# Submit one ad for delayering. Echoes the status_url to poll.
+#   bria_delayer_submit <image-path-or-url> [--prompt "..."] [--effort minimal|low|medium|high]
+bria_delayer_submit() {
+  local image prompt effort payload_file body http_code status_url result_url backoff
+  image="$1"; shift
+  prompt=""; effort=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --prompt) prompt="$2"; shift 2 ;;
+      --effort) effort="$2"; shift 2 ;;
+      *) echo "Unknown option: $1" >&2; return 1 ;;
+    esac
+  done
+  _bria_load_key || return 1
+  if ! printf '%s' "$image" | grep -qE '^https?://'; then
+    [ ! -f "$image" ] && { echo "File not found: $image" >&2; return 1; }
+  fi
+
+  payload_file="/tmp/bria_payload_$$.json"
+  {
+    printf '{"attachments": ["'
+    if printf '%s' "$image" | grep -qE '^https?://'; then
+      printf '%s' "$image"
+    else
+      base64 < "$image" | tr -d '\n\r'
+    fi
+    printf '"], "sync": false, "output_format": "json"'
+    # Escape backslashes and quotes, and flatten newlines — the prompt is free text.
+    [ -n "$prompt" ] && printf ', "prompt": "%s"' "$(printf '%s' "$prompt" | tr '\n\r' '  ' | sed 's/\\/\\\\/g; s/"/\\"/g')"
+    [ -n "$effort" ] && printf ', "thinking_effort": "%s"' "$effort"
+    printf '}'
+  } > "$payload_file" || { rm -f "$payload_file"; return 1; }
+
+  local response_file="/tmp/bria_submit_$$.json"
+  # This file gets sourced into whatever shell the caller is using, and zsh does not word-split
+  # an unquoted parameter, so the backoff schedule is walked with string ops rather than by
+  # relying on `for x in $SCHEDULE` splitting it.
+  local remaining="$BRIA_RETRY_BACKOFF"
+  while : ; do
+    http_code=$(curl -s -o "$response_file" -w '%{http_code}' -X POST \
+      "${BRIA_API_BASE}/v2/ads/image_to_layers" \
+      -H "api_token: $BRIA_API_KEY" \
+      -H "Content-Type: application/json" \
+      -H "User-Agent: $BRIA_USER_AGENT" \
+      --data-binary "@$payload_file")
+    [ "$http_code" != "429" ] && break
+    [ -z "$remaining" ] && break
+    backoff="${remaining%% *}"
+    case "$remaining" in *" "*) remaining="${remaining#* }" ;; *) remaining="" ;; esac
+    echo "Bria is rate-limiting this account — waiting ${backoff}s before retrying." >&2
+    sleep "$backoff"
+  done
+  body=$(cat "$response_file" 2>/dev/null)
+  rm -f "$payload_file" "$response_file"
+
+  if [ "${http_code:-0}" -ge 400 ] 2>/dev/null; then
+    _bria_report_error "$http_code" "$(_bria_json_str message "$body")"
+    return 1
+  fi
+
+  status_url=$(_bria_json_str status_url "$body")
+  if [ -n "$status_url" ]; then
+    echo "$status_url"
+    return 0
+  fi
+  # Defensive: a synchronous 200 carries the result pointer directly, with no polling step.
+  result_url=$(printf '%s' "$body" | grep -oE '[^_]"url" *: *"[^"]*"' | head -1 | sed 's/^[^:]*: *"//; s/"$//')
+  [ -n "$result_url" ] && { echo "$result_url"; return 0; }
+  echo "Bria accepted the ad but returned no job to track. Try again." >&2
+  return 1
+}
+
+# Poll a status_url until the run finishes. Echoes the result URL (the layers manifest).
+# Returns 1 for a terminal failure, 2 when the caller should retry the whole job once.
+bria_delayer_wait() {
+  local status_url poll url i code message
+  status_url="$1"
+  # A result pointer instead of a status URL (synchronous submit) needs no polling.
+  case "$status_url" in
+    */v2/status/*) : ;;
+    *) echo "$status_url"; return 0 ;;
+  esac
+  _bria_load_key || return 1
+
+  i=0
+  while [ "$i" -lt "$BRIA_POLL_ATTEMPTS" ]; do
+    sleep "$BRIA_POLL_INTERVAL"
+    poll=$(curl -s "$status_url" -H "api_token: $BRIA_API_KEY" -H "User-Agent: $BRIA_USER_AGENT")
+
+    if printf '%s' "$poll" | grep -qE '"status" *: *"(ERROR|FAILED)"'; then
+      code=$(printf '%s' "$poll" | grep -oE '"code" *: *[0-9]+' | head -1 | sed 's/[^0-9]//g')
+      message=$(_bria_json_str message "$poll")
+      _bria_report_error "${code:-500}" "$message"
+      [ "$BRIA_DELAYER_RETRYABLE" = "1" ] && return 2
+      return 1
+    fi
+    if printf '%s' "$poll" | grep -qE '"status" *: *"UNKNOWN"'; then
+      echo "That delayering run is no longer on file — Bria keeps job status for about a day. Run it again." >&2
+      return 1
+    fi
+
+    url=$(printf '%s' "$poll" | grep -oE '[^_]"url" *: *"[^"]*"' | head -1 | sed 's/^[^:]*: *"//; s/"$//')
+    [ -n "$url" ] && { echo "$url"; return 0; }
+
+    if printf '%s' "$poll" | grep -qE '"status" *: *"COMPLETED"'; then
+      echo "Bria reported the run complete but returned no layers. Run it again." >&2
+      return 1
+    fi
+    i=$((i + 1))
+  done
+
+  echo "Delayering is still running after $((BRIA_POLL_ATTEMPTS * BRIA_POLL_INTERVAL)) seconds; it may still finish." >&2
+  echo "Resume checking it with: curl -s \"$status_url\" -H \"api_token: \$BRIA_API_KEY\"" >&2
+  return 1
+}
+
+# Fetch the layers manifest and every layer asset into <input-stem>-layers/.
+#   bria_delayer_download <result_url> <original-input> [output-dir]
+bria_delayer_download() {
+  local result_url input out_dir stem manifest pairs id url name ext saved
+  result_url="$1"; input="$2"; out_dir="$3"
+
+  stem="${input##*/}"; stem="${stem%%\?*}"; stem="${stem%.*}"
+  stem=$(printf '%s' "$stem" | tr -cd 'A-Za-z0-9._-')
+  [ -z "$stem" ] && stem="ad"
+  [ -z "$out_dir" ] && out_dir="${stem}-layers"
+  mkdir -p "$out_dir" || return 1
+
+  manifest="$out_dir/result.json"
+  if ! curl -sfL "$result_url" -H "User-Agent: $BRIA_USER_AGENT" -o "$manifest"; then
+    echo "The layers manifest could not be downloaded. Run the ad again." >&2
+    return 1
+  fi
+  echo "saved $manifest"
+
+  # The manifest lists each layer's "id" before its "asset_path", so walking the two keys
+  # in document order pairs every asset with the layer id it belongs to.
+  pairs=$(grep -oE '"(id|asset_path)" *: *"[^"]*"' "$manifest")
+  id=""; saved=0
+  while IFS= read -r line; do
+    case "$line" in
+      '"id"'*)
+        id=$(printf '%s' "$line" | sed 's/^[^:]*: *"//; s/"$//') ;;
+      '"asset_path"'*)
+        url=$(printf '%s' "$line" | sed 's/^[^:]*: *"//; s/"$//')
+        [ -z "$id" ] && continue
+        ext=$(printf '%s' "$url" | sed 's/[?#].*$//' | sed -n 's/.*\.\([A-Za-z0-9]\{1,5\}\)$/\1/p')
+        [ -z "$ext" ] && ext="png"
+        name=$(printf '%s' "$id" | tr -cd 'A-Za-z0-9._-')
+        if curl -sfL "$url" -H "User-Agent: $BRIA_USER_AGENT" -o "$out_dir/${name}.${ext}"; then
+          echo "saved $out_dir/${name}.${ext}"
+          saved=$((saved + 1))
+        else
+          echo "Layer '$id' could not be downloaded." >&2
+        fi ;;
+    esac
+  done <<< "$pairs"
+
+  echo "$saved layer image(s) plus result.json in $out_dir"
+  return 0
+}
+
+# Delayer one ad end to end: submit, wait, download.
+#   bria_delayer <image-path-or-url> [--prompt "..."] [--effort ...] [--out-dir DIR]
+bria_delayer() {
+  local image out_dir args status_url result_url rc attempt request_id
+  image="$1"; shift
+  out_dir=""; args=()
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --out-dir) out_dir="$2"; shift 2 ;;
+      *) args+=("$1"); shift ;;
+    esac
+  done
+
+  attempt=1
+  while : ; do
+    status_url=$(bria_delayer_submit "$image" "${args[@]}") || return 1
+    case "$status_url" in */v2/status/*) request_id="${status_url##*/}" ;; esac
+    result_url=$(bria_delayer_wait "$status_url")
+    rc=$?
+    [ "$rc" -eq 0 ] && break
+    if [ "$rc" -eq 2 ] && [ "$attempt" -eq 1 ]; then
+      attempt=2
+      echo "Retrying the ad once." >&2
+      continue
+    fi
+    [ "$rc" -eq 2 ] && echo "Delayering failed twice. Contact Bria support with request_id $request_id" >&2
+    return 1
+  done
+
+  bria_delayer_download "$result_url" "$image" "$out_dir"
+}

--- a/skills/bria-ai/SKILL.md
+++ b/skills/bria-ai/SKILL.md
@@ -311,4 +311,5 @@ Bria generates images, not text — **you, the agent, write the copy**. `build_c
 ## Related Skills
 
 - **vgl** — Write structured VGL JSON prompts for precise, deterministic control over FIBO image generation
+- **ad-delayer** — Take a finished, flat ad apart into editable layers (background, logo, copy, CTA) when the design file is gone
 - **image-utils** — Classic image manipulation (resize, crop, composite, watermarks) for post-processing

--- a/skills/remove-background/SKILL.md
+++ b/skills/remove-background/SKILL.md
@@ -258,5 +258,6 @@ RMBG 2.0 handles complex edges with production-grade accuracy:
 
 ## Related Skills
 
+- **ad-delayer** — Take a whole flat ad apart into editable layers, keeping text as text. Use it instead of this skill when the ask is "turn this ad into layers", not "cut out the subject"
 - **bria-ai** — Full Bria API access: generate images, edit photos, replace/blur backgrounds, upscale, restyle, product photography, and 20+ more endpoints
 - **image-utils** — Post-processing with Python Pillow: resize, crop, composite, watermarks, format conversion


### PR DESCRIPTION

Adds `skills/ad-delayer` — a dedicated skill for taking a finished, flat ad image apart into
editable layers via Bria's Ad Delayer — and registers it everywhere the other skills are
registered. [BLD-168](https://bria-ai.atlassian.net/browse/BLD-168), epic
[PRD-165](https://bria-ai.atlassian.net/browse/PRD-165).

> **Work in progress — draft.** The skill is complete and verified against a stand-in API, but the
> live end-to-end runs against production and the clean-container install test are still to come;
> both need an interactive Bria sign-in. I'll mark this ready for review once those are attached.

## Where this code actually runs

- **A designer in Claude Code who lost the design file.** They say "I lost the PSD for this ad —
  turn it into layers" (or "delayer this", or "make this ad editable"). Claude loads
  `skills/ad-delayer`, sources `bria_delayer_client.sh`, submits the ad, waits out the 2–3 minute
  run, and leaves a `<ad-name>-layers/` folder in their project: `result.json` plus one PNG per
  image layer, each named after its layer id. The designer never sees an endpoint, a token, a
  poll, or a JSON payload — they get files and a plain-language summary of what the ad is made of.
- **`/plugin install ad-delayer@bria-skills`.** The new `plugins[]` entry in
  `.claude-plugin/marketplace.json` is what that command resolves to, and what the Build page's
  install link will point at. It carries its own `BRIA_API_KEY` env dependency block, like
  `remove-background` does.
- **Bria's own traffic attribution.** Every call the skill makes — submit, status poll, manifest
  fetch, asset download — carries `User-Agent: BriaSkills/1.3.7`. That header is how delayering
  requests coming from the skill surface are told apart from Build-page or direct-API traffic.
- **The release pipeline, on merge.** `Release Skills` globs `skills/*/`, so merging this zips
  `ad-delayer.skill` into the `v1.3.7` GitHub release — the artifact the installer actually
  downloads. No workflow change was needed.

**Verified:** 34 clean-room runs — a fresh headless agent per case with only the skill in scope,
all HTTP traffic captured by a stand-in Bria API, graded from the captured requests and the files
on disk rather than from what the agent said it did. 10/10 on capability, 12/12 on the error
table's retry policy and messages, 7/7 on routing in both directions. The live end-to-end runs and
the clean-container install test are not done yet — both need an interactive Bria sign-in. Results:
https://claude.ai/code/artifact/43231c7d-af44-4c8a-808c-071ce5716559

## What's in the change

| File | What |
|---|---|
| `skills/ad-delayer/SKILL.md` | The skill: when to use, when not to, the shared device-flow auth section, the one-call flow, input/options/output contracts, five examples, the error table |
| `skills/ad-delayer/references/api-endpoints.md` | The endpoint contract as implemented — request fields, the three-hop async flow, the layer-manifest schema, the real error shapes |
| `skills/ad-delayer/references/code-examples/bria_delayer_client.sh` | `bria_delayer` end to end, plus `bria_delayer_submit` / `_wait` / `_download`. curl + sed + base64 only, no jq |
| `.claude-plugin/marketplace.json`, `package.json`, `bin/cli.js`, `README.md`, `.gitignore` | Registration and the 1.3.7 version bump |
| `skills/bria-ai/SKILL.md`, `skills/remove-background/SKILL.md` | Reciprocal `Related Skills` rows, and the cutout-vs-delayering disambiguation on the remove-background side |

## Decisions in this change

- **Claude tree only.** The skill ships under `skills/` and is not hand-copied into the `kiro/`
  or `bria-ai-openclaw/` variant trees; `automotive` already sets that precedent. The fan-out is
  its own ticket.
- **`image_to_layers`, not `delayer`.** Both paths exist in the ads service, but the load
  balancer routes only `image_to_layers` (and `image_to_template`, `extract_objects`) to the ads
  service in int and prod — `/v2/ads/delayer` falls through to a different service and is
  unreachable from the public API. The skill and its reference document `image_to_layers` only.
- **Errors are mapped from the real API, not from a symbolic registry.** The API emits
  `{code: <http status>, message, details}`; the symbolic error registry
  (`INVALID_IMAGE`, `IMAGE_DIMENSIONS_EXCEEDED`, …) exists in the spec but not in the service.
  The skill maps the messages the service actually returns onto one cause-plus-action sentence
  each, so nothing breaks when the registry does get built. Two rows the spec describes — the
  800px dimension cap and a 10 MB limit — are not in the table, because nothing emits them; they
  land in the same table when the server-side work exists.
- **The error mapping reads both the submit response and the status poll.** Because delayering is
  async, the submit returns 202 before the work starts, so only auth, rate-limit, and
  request-shape failures come back on the submit. Every image-validation failure and every
  pipeline error arrives later, inside the status response's `error` object. Both paths run
  through the same mapper.
- **The backoff schedule is walked with POSIX string operations, not `for x in $SCHEDULE`.** The
  client is sourced into the caller's shell, and zsh — the macOS default, and what Claude Code's
  Bash tool uses — does not word-split an unquoted parameter, so the loop ran once with the whole
  schedule as a single word and `sleep "20 40 60"` failed instantly. Verified from both shells.
- **Retry policy.** 4xx: no retry, mapped message. Job failure or 500: the whole ad is retried
  exactly once, then the user gets the `request_id` to give support — and the `request_id`
  appears nowhere else in the output. 429: automatic backoff at 20s/40s/60s. Status `UNKNOWN`:
  no retry, because it means the job aged out of Bria's one-day status retention.
- **Poll defaults are 10s × 36 (a 6-minute ceiling)** for runs that take 2–3 minutes today, with
  `BRIA_POLL_INTERVAL` / `BRIA_POLL_ATTEMPTS` overrides. On timeout the client prints the command
  to resume checking the same job rather than resubmitting, since the run continues server-side.
- **Helper paths resolve relative to the skill directory** (`<SKILL_DIR>/references/…`, the
  `bria-ai` convention) rather than the hard-coded `~/.agents/skills/…` that
  `remove-background` and `video-remove-background` use. A `/plugin install` puts the skill
  somewhere else entirely, and the hard-coded path does not resolve there.
- **`bin/cli.js` also picked up the missing `video-remove-background` entry** — its `SKILLS` list
  and help text had never been updated for that skill, and it is the same two lines this change
  edits for `ad-delayer`.
- **The error table carries three rules about how to react to it**, added after the runs showed
  agents working around it: only the 401/403 row is an authentication problem (an image rejection
  had sent one agent back through the OAuth sign-in flow); the helper already applies the retry
  policy, so the same ad is never re-submitted by hand, because every submit is a billed 2–3 minute
  run; and the user is told the cause and the fix, not the endpoints and poll counts.
- **Version 1.3.7.** `main` is on 1.3.5 and open PR #54 claims 1.3.6, so this branch takes the
  next free number, stamped in `package.json`, `marketplace.json`, the skill frontmatter, the
  client's `BRIA_USER_AGENT`, and the reference header.
