### PR TITLE
feat: Multi-reference image editing across the skill variants (BLD-179)

### DIFF
--- a/bria-ai-openclaw/skills/bria-ai/SKILL.md
+++ b/bria-ai-openclaw/skills/bria-ai/SKILL.md
@@ -111,6 +111,9 @@ Generate image from scratch (text → image)?
 Edit existing image with text instruction?
   → /v2/image/edit  (use --key images)
 
+Combine 2-4 images — outfit, product, logo, style, or background from one into another?
+  → /v2/image/edit  (--key images, then one --image per extra reference)
+
 Change / replace / blur background?
   → /v2/image/edit/replace_background  (prompt: "blur" or describe new bg)
 
@@ -143,6 +146,11 @@ RESULT=$(bria_call /v2/image/edit/replace_background "https://example.com/img.jp
 # Edit image (uses images array — pass --key images)
 RESULT=$(bria_call /v2/image/edit "/path/to/image.png" --key images '"instruction": "make it look warmer"')
 
+# Edit with reference images — each --image adds the next one, in order
+RESULT=$(bria_call /v2/image/edit "https://example.com/man.jpg" --key images \
+  --image "https://example.com/santa.png" \
+  '"instruction": "dress the man in image 1 in the santa outfit from image 2"')
+
 # Upscale
 RESULT=$(bria_call /v2/image/edit/increase_resolution "https://example.com/img.jpg" '"desired_increase": 4')
 
@@ -155,9 +163,17 @@ echo "$RESULT"
 **Calling convention:** `bria_call <endpoint> <image_or_empty> [--key <json_key>] [extra JSON fields...]`
 - Pass a URL, local file path, or `""` for endpoints without image input
 - Use `--key images` when the endpoint expects an `images` array instead of `image`
+- Add `--image <url_or_path>` once per extra reference image (`--key images`, up to 4 in total).
+  Order is preserved: the positional image is "image 1", the first `--image` is "image 2", …
 - Returns the result image URL on success, or prints an error to stderr
 
-**Generation options:** Aspect ratios `1:1`, `16:9`, `4:3`, `9:16`, `3:4`. Resolution `1MP` (default) or `4MP` (more detail, +30s). Pass `"sync": true` for single images.
+**Editing with several images (2-4):** put the image being edited first, references after it, and
+address them by position — *"dress the man in image 1 in the santa outfit from image 2"*. Say what
+each reference contributes, in plain prose. Single-image edits need no positional wording.
+
+**Generation options:** Aspect ratios `1:1`, `16:9`, `4:3`, `9:16`, `3:4`. Resolution `1MP` (default) or `4MP` (more detail, +30s). Pass `"sync": true` for a single generated image. Editing endpoints are the other way round —
+they answer with a `status_url` you poll, and `"sync": true` on an edit fails with a gateway
+timeout.
 
 > **Advanced**: For precise control over generation, use the **vgl** skill for structured VGL JSON prompts.
 

--- a/bria-ai-openclaw/skills/bria-ai/references/api-endpoints.md
+++ b/bria-ai-openclaw/skills/bria-ai/references/api-endpoints.md
@@ -119,7 +119,9 @@ Remove background from image. Returns PNG with transparency.
 
 ### POST /v2/image/edit
 
-Edit an image using natural language instructions. No mask required.
+Edit an image with a natural language instruction — no mask required. Send one image to change it,
+or 2–4 images to combine them: the subject from one with an outfit, product, style, or background
+from another.
 
 **Request:**
 ```json
@@ -129,12 +131,62 @@ Edit an image using natural language instructions. No mask required.
 }
 ```
 
+**Multi-reference request.** `images` is ordered, and the instruction addresses each entry by its
+position — the first is "image 1", the second "image 2", and so on:
+```json
+{
+  "images": ["https://man-image-url", "https://santa-outfit-image-url"],
+  "instruction": "dress the man in image 1 in the santa outfit from image 2",
+  "seed": 1234
+}
+```
+
 **Parameters:**
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `images` | array | required | Array of image URLs or base64 data URLs |
-| `instruction` | string | required | Edit instruction in natural language |
+| `images` | array | required | 1–4 image URLs or base64 data URLs. **Order matters** — the instruction refers to them as "image 1", "image 2", … in the order they are sent |
+| `instruction` | string | required | Edit instruction in natural language. Refer to additional images by position |
+| `seed` | int | random | For reproducibility — the same images, instruction and seed reproduce the same result |
+| `aspect_ratio` | string | - | Output ratio: "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9". Honored only with 2 or more images. Do not send it on a single-image request — the output follows that image regardless and the response carries a `warning`; to change one image's ratio, use `/v2/image/edit/expand` |
+| `model_version` | string | - | Deprecated and ignored — the service picks the edit model from the request contents. A value that is sent comes back with a notice in `warning`; omit it |
+
+**Writing a multi-reference instruction:**
+- Put the image being edited first and the references after it.
+- Say what each reference contributes ("the outfit from image 2", "the background of image 3"), not
+  just that it exists.
+- Plain prose, plain words — "image 1", "image 2". No brackets, tags, or markup.
+
+This endpoint is asynchronous: it answers with `request_id` and `status_url`, which you poll. Do
+not send `"sync": true` here — an instruction edit takes longer than a single response is allowed to
+take, so a synchronous request fails with a gateway timeout even though the job itself is fine.
+
+**Constraints** — each returns 422 with a readable message:
+- More than 4 images. Trim the set before sending; the request is refused, not truncated.
+- A `mask` together with 2 or more images (masked edits are single-image only).
+- 2 or more images together with a tailored `model_id` or `model_version: FIBO_BBQ` — both of those
+  run on the single-reference model.
+
+**Completed Result:**
+```json
+{
+  "status": "COMPLETED",
+  "result": {
+    "image_url": "https://...",
+    "seed": 1234,
+    "structured_prompt": "{...}",
+    "warning": null
+  }
+}
+```
+
+The result also carries the structured instruction the edit was rendered from — named
+`structured_prompt` on a polled result and `structured_instruction` on an inline `"sync": true`
+response. Read whichever is present.
+
+`warning` is set when a parameter was accepted but not honored — `aspect_ratio` on a single-image
+request, a supplied `model_version`, or a tuning parameter the serving model does not read. Relay it
+to the user rather than dropping it.
 
 ### POST /v2/image/edit/gen_fill
 

--- a/bria-ai-openclaw/skills/bria-ai/references/capabilities.md
+++ b/bria-ai-openclaw/skills/bria-ai/references/capabilities.md
@@ -18,6 +18,7 @@
 |------|------------|----------|
 | Generate images from text | FIBO Generate | `/v2/image/generate` |
 | Edit images by text instruction | FIBO-Edit | `/v2/image/edit` |
+| Combine 2-4 images in one edit | FIBO-Edit multi-reference | `/v2/image/edit` (ordered `images` array) |
 | Edit image region with mask | GenFill/Erase | `/v2/image/edit/gen_fill` |
 | Add/Replace/Remove objects | Text-based editing | `/v2/image/edit` |
 | Remove background (transparent PNG) | RMBG-2.0 | `/v2/image/edit/remove_background` |

--- a/bria-ai-openclaw/skills/bria-ai/references/code-examples/bria_client.sh
+++ b/bria-ai-openclaw/skills/bria-ai/references/code-examples/bria_client.sh
@@ -8,6 +8,12 @@
 #   RESULT=$(bria_call /v2/image/edit/remove_background "/path/to/image.png")
 #   RESULT=$(bria_call /v2/image/edit/replace_background "https://example.com/img.jpg" '"prompt":"sunset beach"')
 #   RESULT=$(bria_call /v2/image/edit "/path/to/image.png" --key images '"instruction":"make it red"')
+#   RESULT=$(bria_call /v2/image/edit "https://example.com/man.jpg" --key images \
+#     --image "https://example.com/santa.png" \
+#     '"instruction":"dress the man in image 1 in the santa outfit from image 2"')
+#
+# Each extra --image adds the next reference image, in order: the positional image is "image 1",
+# the first --image is "image 2", and so on. Only the images array (--key images) takes references.
 #
 # BRIA_API_KEY is auto-loaded from ~/.bria/credentials if not already set.
 
@@ -15,13 +21,15 @@ BRIA_API_BASE="${BRIA_API_BASE:-https://engine.prod.bria-api.com}"
 BRIA_USER_AGENT="BriaSkills/1.3.5"
 
 bria_call() {
-  local endpoint image key extra payload result http_code body url status_url poll i
+  local endpoint image key extra payload result http_code body url status_url poll i img
+  local references=()
   endpoint="$1"; image="$2"; shift 2
 
   key="image"; extra=""
   while [ $# -gt 0 ]; do
     case "$1" in
       --key) key="$2"; shift 2 ;;
+      --image) references+=("$2"); shift 2 ;;
       *) extra="${extra:+$extra, }$1"; shift ;;
     esac
   done
@@ -36,25 +44,32 @@ bria_call() {
 
   if [ -z "$image" ]; then
     printf '{' > "$payload"
+  elif [ "$key" = "images" ]; then
+    # Written one entry at a time, in argument order: the array position is how the instruction
+    # addresses each image ("image 1", "image 2"), so nothing here may reorder them.
+    printf '{"images": [' > "$payload"
+    i=0
+    # ${arr[@]+"${arr[@]}"} expands to nothing for an empty array instead of failing under `set -u`.
+    for img in "$image" ${references[@]+"${references[@]}"}; do
+      [ "$i" -gt 0 ] && printf ', ' >> "$payload"
+      if printf '%s' "$img" | grep -qE '^https?://'; then
+        printf '"%s"' "$img" >> "$payload"
+      else
+        [ ! -f "$img" ] && { echo "ERROR: File not found: $img" >&2; return 1; }
+        printf '"' >> "$payload"
+        base64 < "$img" | tr -d '\n' >> "$payload"
+        printf '"' >> "$payload"
+      fi
+      i=$((i + 1))
+    done
+    printf ']' >> "$payload"
   elif printf '%s' "$image" | grep -qE '^https?://'; then
-    if [ "$key" = "images" ]; then
-      printf '{"images": ["%s"]' "$image" > "$payload"
-    else
-      printf '{"%s": "%s"' "$key" "$image" > "$payload"
-    fi
+    printf '{"%s": "%s"' "$key" "$image" > "$payload"
   else
     [ ! -f "$image" ] && { echo "ERROR: File not found: $image" >&2; return 1; }
-    if [ "$key" = "images" ]; then
-      printf '{"images": ["' > "$payload"
-    else
-      printf '{"%s": "' "$key" > "$payload"
-    fi
+    printf '{"%s": "' "$key" > "$payload"
     base64 < "$image" | tr -d '\n' >> "$payload"
-    if [ "$key" = "images" ]; then
-      printf '"]' >> "$payload"
-    else
-      printf '"' >> "$payload"
-    fi
+    printf '"' >> "$payload"
   fi
 
   if [ -n "$extra" ]; then

--- a/kiro/bria-ai/POWER.md
+++ b/kiro/bria-ai/POWER.md
@@ -149,6 +149,7 @@ Interpret the output:
 |------|------------|----------|
 | Generate images from text | FIBO Generate | Hero images, product shots, illustrations, social media images, banners |
 | Edit images by text instruction | FIBO-Edit | Change colors, modify objects, transform scenes |
+| Combine 2–4 images in one edit | FIBO-Edit multi-reference | Put the outfit, product, logo, style, or background of one image into another |
 | Edit image region with mask | GenFill/Erase | Precise inpainting, add/replace specific regions |
 | Add/Replace/Remove objects | Text-based editing | Add vase, replace apple with pear, remove table |
 | Remove background (transparent PNG) | RMBG-2.0 | Extract subjects for overlays, logos, cutouts |
@@ -187,6 +188,11 @@ RESULT=$(bria_call /v2/image/edit/replace_background "https://example.com/img.jp
 # Edit image (uses images array — pass --key images)
 RESULT=$(bria_call /v2/image/edit "/path/to/image.png" --key images '"instruction": "make it look warmer"')
 
+# Edit with reference images — each --image adds the next one, in order
+RESULT=$(bria_call /v2/image/edit "https://example.com/man.jpg" --key images \
+  --image "https://example.com/santa.png" \
+  '"instruction": "dress the man in image 1 in the santa outfit from image 2"')
+
 # Upscale
 RESULT=$(bria_call /v2/image/edit/increase_resolution "https://example.com/img.jpg" '"desired_increase": 4')
 
@@ -205,10 +211,21 @@ echo "$RESULT"
 **Calling convention:** `bria_call <endpoint> <image_or_empty> [--key <json_key>] [extra JSON fields...]`
 - Pass a URL, local file path, or `""` (empty) for endpoints without image input
 - Use `--key images` when the endpoint expects an `images` array instead of `image`
+- Add `--image <url_or_path>` once per extra reference image (`--key images`, up to 4 in total).
+  Order is preserved: the positional image is "image 1", the first `--image` is "image 2", …
 - Extra JSON fields are appended as key-value pairs: `'"key": "value"'`
 - Returns the result image URL on success, or prints an error to stderr
 
-**Generation options:** Aspect ratios `1:1`, `16:9`, `4:3`, `9:16`, `3:4`. Resolution `1MP` (default) or `4MP` (more detail, +30s). Pass `"sync": true` for single images.
+**Editing with several images (2–4):** reach for a second image when the look the user wants
+already exists as a picture — a specific outfit, product, logo, or scene — instead of something you
+can describe in words. Put the image being edited first, references after it, and address them by
+position in the instruction: *"dress the man in image 1 in the santa outfit from image 2"*. Say what
+each reference contributes ("the background of image 3"), in plain prose. A single-image edit needs
+no positional wording: *"change the mug color to red"*.
+
+**Generation options:** Aspect ratios `1:1`, `16:9`, `4:3`, `9:16`, `3:4`. Resolution `1MP` (default) or `4MP` (more detail, +30s). Pass `"sync": true` for a single generated image. Editing endpoints are the other way round —
+they answer with a `status_url` you poll, and `"sync": true` on an edit fails with a gateway
+timeout.
 
 > **Advanced**: For precise control over generation, use the **vgl** power for structured VGL JSON prompts instead of natural language.
 

--- a/kiro/bria-ai/steering/api-endpoints.md
+++ b/kiro/bria-ai/steering/api-endpoints.md
@@ -119,7 +119,9 @@ Remove background from image. Returns PNG with transparency.
 
 ### POST /v2/image/edit
 
-Edit an image using natural language instructions. No mask required.
+Edit an image with a natural language instruction — no mask required. Send one image to change it,
+or 2–4 images to combine them: the subject from one with an outfit, product, style, or background
+from another.
 
 **Request:**
 ```json
@@ -129,12 +131,62 @@ Edit an image using natural language instructions. No mask required.
 }
 ```
 
+**Multi-reference request.** `images` is ordered, and the instruction addresses each entry by its
+position — the first is "image 1", the second "image 2", and so on:
+```json
+{
+  "images": ["https://man-image-url", "https://santa-outfit-image-url"],
+  "instruction": "dress the man in image 1 in the santa outfit from image 2",
+  "seed": 1234
+}
+```
+
 **Parameters:**
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `images` | array | required | Array of image URLs or base64 data URLs |
-| `instruction` | string | required | Edit instruction in natural language |
+| `images` | array | required | 1–4 image URLs or base64 data URLs. **Order matters** — the instruction refers to them as "image 1", "image 2", … in the order they are sent |
+| `instruction` | string | required | Edit instruction in natural language. Refer to additional images by position |
+| `seed` | int | random | For reproducibility — the same images, instruction and seed reproduce the same result |
+| `aspect_ratio` | string | - | Output ratio: "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9". Honored only with 2 or more images. Do not send it on a single-image request — the output follows that image regardless and the response carries a `warning`; to change one image's ratio, use `/v2/image/edit/expand` |
+| `model_version` | string | - | Deprecated and ignored — the service picks the edit model from the request contents. A value that is sent comes back with a notice in `warning`; omit it |
+
+**Writing a multi-reference instruction:**
+- Put the image being edited first and the references after it.
+- Say what each reference contributes ("the outfit from image 2", "the background of image 3"), not
+  just that it exists.
+- Plain prose, plain words — "image 1", "image 2". No brackets, tags, or markup.
+
+This endpoint is asynchronous: it answers with `request_id` and `status_url`, which you poll. Do
+not send `"sync": true` here — an instruction edit takes longer than a single response is allowed to
+take, so a synchronous request fails with a gateway timeout even though the job itself is fine.
+
+**Constraints** — each returns 422 with a readable message:
+- More than 4 images. Trim the set before sending; the request is refused, not truncated.
+- A `mask` together with 2 or more images (masked edits are single-image only).
+- 2 or more images together with a tailored `model_id` or `model_version: FIBO_BBQ` — both of those
+  run on the single-reference model.
+
+**Completed Result:**
+```json
+{
+  "status": "COMPLETED",
+  "result": {
+    "image_url": "https://...",
+    "seed": 1234,
+    "structured_prompt": "{...}",
+    "warning": null
+  }
+}
+```
+
+The result also carries the structured instruction the edit was rendered from — named
+`structured_prompt` on a polled result and `structured_instruction` on an inline `"sync": true`
+response. Read whichever is present.
+
+`warning` is set when a parameter was accepted but not honored — `aspect_ratio` on a single-image
+request, a supplied `model_version`, or a tuning parameter the serving model does not read. Relay it
+to the user rather than dropping it.
 
 ### POST /v2/image/edit/gen_fill
 

--- a/kiro/bria-ai/steering/bria-client-bash.sh
+++ b/kiro/bria-ai/steering/bria-client-bash.sh
@@ -427,16 +427,37 @@ bria_blur_background() {
 }
 
 bria_edit_image() {
-  local image_url
-  image_url=$(bria_resolve_image "$1" "data_url")
-  local instruction="$2"
-  local mask_url="${3:-}"
+  # Usage: bria_edit_image <image> <instruction> [mask_url] [--image <reference>]...
+  # The images array is ordered: <image> is "image 1", each --image adds the next reference.
+  local references=() ref image_url="" instruction="" mask_url="" seen=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --image) references+=("$2"); shift 2 ;;
+      # Assigned by position rather than read out of an array: bash indexes arrays from 0 and
+      # zsh from 1, and this file gets sourced from both.
+      *)
+        case "$seen" in
+          0) image_url="$1" ;;
+          1) instruction="$1" ;;
+          2) mask_url="$1" ;;
+        esac
+        seen=$((seen + 1)); shift ;;
+    esac
+  done
+
+  image_url=$(bria_resolve_image "$image_url" "data_url")
 
   local data
   data=$(jq -n \
     --arg image "$image_url" \
     --arg inst "$instruction" \
     '{images: [$image], instruction: $inst}')
+
+  if [[ ${#references[@]} -gt 0 ]]; then
+    for ref in "${references[@]}"; do
+      data=$(echo "$data" | jq --arg ref "$(bria_resolve_image "$ref" "data_url")" '.images += [$ref]')
+    done
+  fi
 
   if [[ -n "$mask_url" ]]; then
     local resolved_mask

--- a/kiro/bria-ai/steering/bria-client-python.py
+++ b/kiro/bria-ai/steering/bria-client-python.py
@@ -25,7 +25,7 @@ import base64
 import time
 import mimetypes
 import requests
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List, Union
 
 
 class BriaClient:
@@ -513,7 +513,7 @@ class BriaClient:
 
     def edit_image(
         self,
-        image_url: str,
+        image_url: Union[str, List[str]],
         instruction: str,
         mask_url: Optional[str] = None,
         wait: bool = True,
@@ -522,16 +522,21 @@ class BriaClient:
         Edit an image using natural language instructions.
 
         Args:
-            image_url: Source image URL or base64 data URL
-            instruction: Edit instruction (e.g., "change the mug to red")
-            mask_url: Optional mask for localized editing (white=edit, black=keep)
+            image_url: Source image URL or base64 data URL, or a list of 2-4 of them to
+                combine. The list is ordered, and the instruction addresses each entry by
+                position: the first is "image 1", the second "image 2", and so on.
+            instruction: Edit instruction (e.g., "change the mug to red", or
+                "dress the man in image 1 in the santa outfit from image 2")
+            mask_url: Optional mask for localized editing (white=edit, black=keep).
+                Supported for single-image edits only.
             wait: Wait for completion
 
         Returns:
             Dict with edited image_url
         """
+        images = [image_url] if isinstance(image_url, str) else list(image_url)
         data = {
-            "images": [self._resolve_image(image_url, as_data_url=True)],
+            "images": [self._resolve_image(image, as_data_url=True) for image in images],
             "instruction": instruction,
         }
         if mask_url:

--- a/kiro/bria-ai/steering/bria-client-typescript.ts
+++ b/kiro/bria-ai/steering/bria-client-typescript.ts
@@ -521,20 +521,25 @@ export class BriaClient {
 
   /**
    * Edit an image using natural language instructions.
-   * @param imageUrl - Source image URL or base64 data URL
-   * @param instruction - Edit instruction (e.g., "change the mug to red")
-   * @param maskUrl - Optional mask for localized editing (white=edit, black=keep)
+   * @param imageUrl - Source image URL or base64 data URL, or an array of 2-4 of them to
+   *                   combine. The array is ordered, and the instruction addresses each entry
+   *                   by position: the first is "image 1", the second "image 2", and so on.
+   * @param instruction - Edit instruction (e.g., "change the mug to red", or
+   *                      "dress the man in image 1 in the santa outfit from image 2")
+   * @param maskUrl - Optional mask for localized editing (white=edit, black=keep).
+   *                  Supported for single-image edits only.
    * @param wait - Wait for completion
    * @returns Response with edited image_url
    */
   async editImage(
-    imageUrl: string,
+    imageUrl: string | string[],
     instruction: string,
     maskUrl?: string,
     wait = true
   ): Promise<BriaResponse> {
+    const images = Array.isArray(imageUrl) ? imageUrl : [imageUrl];
     const data: Record<string, unknown> = {
-      images: [this.resolveImage(imageUrl, true)],
+      images: images.map((image) => this.resolveImage(image, true)),
       instruction,
     };
     if (maskUrl) data.mask = this.resolveImage(maskUrl, true);

--- a/preambles/image-input-handling.md
+++ b/preambles/image-input-handling.md
@@ -29,4 +29,9 @@ RESULT_URL=$(bria_call /v2/image/edit/replace_background "https://example.com/im
 
 # Edit image (uses images array)
 RESULT_URL=$(bria_call /v2/image/edit "/path/to/image.png" --key images '"instruction": "make it warmer"')
+
+# Edit with reference images — each --image adds the next one, in order ("image 1", "image 2", …)
+RESULT_URL=$(bria_call /v2/image/edit "https://example.com/man.jpg" --key images \
+  --image "https://example.com/santa.png" \
+  '"instruction": "dress the man in image 1 in the santa outfit from image 2"')
 ```

--- a/skills/bria-ai/SKILL.md
+++ b/skills/bria-ai/SKILL.md
@@ -150,6 +150,7 @@ Interpret the output:
 |------|------------|----------|
 | Generate images from text | FIBO Generate | Hero images, product shots, illustrations, social media images, banners |
 | Edit images by text instruction | FIBO-Edit | Change colors, modify objects, transform scenes |
+| Combine 2–4 images in one edit | FIBO-Edit multi-reference | Put the outfit, product, logo, style, or background of one image into another |
 | Edit image region with mask | GenFill/Erase | Precise inpainting, add/replace specific regions |
 | Add/Replace/Remove objects | Text-based editing | Add vase, replace apple with pear, remove table |
 | Remove background (transparent PNG) | RMBG-2.0 | Extract subjects for overlays, logos, cutouts |
@@ -193,6 +194,11 @@ RESULT=$(bria_call /v2/image/edit/replace_background "https://example.com/img.jp
 # Edit image (uses images array — pass --key images)
 RESULT=$(bria_call /v2/image/edit "/path/to/image.png" --key images '"instruction": "make it look warmer"')
 
+# Edit with reference images — each --image adds the next one, in order
+RESULT=$(bria_call /v2/image/edit "https://example.com/man.jpg" --key images \
+  --image "https://example.com/santa.png" \
+  '"instruction": "dress the man in image 1 in the santa outfit from image 2"')
+
 # Upscale (`desired_increase` is 2 or 4 — no other value. Transparency is preserved by default)
 RESULT=$(bria_call /v2/image/edit/increase_resolution "https://example.com/img.jpg" '"desired_increase": 4')
 
@@ -217,10 +223,21 @@ echo "$RESULT"
 **Calling convention:** `bria_call <endpoint> <image_or_empty> [--key <json_key>] [extra JSON fields...]`
 - Pass a URL, local file path, or `""` (empty) for endpoints without image input
 - Use `--key images` when the endpoint expects an `images` array instead of `image`
+- Add `--image <url_or_path>` once per extra reference image (`--key images`, up to 4 in total).
+  Order is preserved: the positional image is "image 1", the first `--image` is "image 2", …
 - Extra JSON fields are appended as key-value pairs: `'"key": "value"'`
 - Returns the result image URL on success, or prints an error to stderr
 
-**Generation options:** Aspect ratios `1:1`, `16:9`, `4:3`, `9:16`, `3:4`. Resolution `1MP` (default) or `4MP` (more detail, +30s). Pass `"sync": true` for single images.
+**Editing with several images (2–4):** reach for a second image when the look the user wants
+already exists as a picture — a specific outfit, product, logo, or scene — instead of something you
+can describe in words. Put the image being edited first, references after it, and address them by
+position in the instruction: *"dress the man in image 1 in the santa outfit from image 2"*. Say what
+each reference contributes ("the background of image 3"), in plain prose. A single-image edit needs
+no positional wording: *"change the mug color to red"*.
+
+**Generation options:** Aspect ratios `1:1`, `16:9`, `4:3`, `9:16`, `3:4`. Resolution `1MP` (default) or `4MP` (more detail, +30s). Pass `"sync": true` for a single generated image. Editing endpoints are the other way round —
+they answer with a `status_url` you poll, and `"sync": true` on an edit fails with a gateway
+timeout.
 
 > **Advanced**: For precise control over generation, use the **vgl** skill for structured VGL JSON prompts instead of natural language.
 

--- a/skills/bria-ai/references/api-endpoints.md
+++ b/skills/bria-ai/references/api-endpoints.md
@@ -119,7 +119,9 @@ Remove background from image. Returns PNG with transparency.
 
 ### POST /v2/image/edit
 
-Edit an image using natural language instructions. No mask required.
+Edit an image with a natural language instruction — no mask required. Send one image to change it,
+or 2–4 images to combine them: the subject from one with an outfit, product, style, or background
+from another.
 
 **Request:**
 ```json
@@ -129,12 +131,62 @@ Edit an image using natural language instructions. No mask required.
 }
 ```
 
+**Multi-reference request.** `images` is ordered, and the instruction addresses each entry by its
+position — the first is "image 1", the second "image 2", and so on:
+```json
+{
+  "images": ["https://man-image-url", "https://santa-outfit-image-url"],
+  "instruction": "dress the man in image 1 in the santa outfit from image 2",
+  "seed": 1234
+}
+```
+
 **Parameters:**
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `images` | array | required | Array of image URLs or base64 data URLs |
-| `instruction` | string | required | Edit instruction in natural language |
+| `images` | array | required | 1–4 image URLs or base64 data URLs. **Order matters** — the instruction refers to them as "image 1", "image 2", … in the order they are sent |
+| `instruction` | string | required | Edit instruction in natural language. Refer to additional images by position |
+| `seed` | int | random | For reproducibility — the same images, instruction and seed reproduce the same result |
+| `aspect_ratio` | string | - | Output ratio: "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9". Honored only with 2 or more images. Do not send it on a single-image request — the output follows that image regardless and the response carries a `warning`; to change one image's ratio, use `/v2/image/edit/expand` |
+| `model_version` | string | - | Deprecated and ignored — the service picks the edit model from the request contents. A value that is sent comes back with a notice in `warning`; omit it |
+
+**Writing a multi-reference instruction:**
+- Put the image being edited first and the references after it.
+- Say what each reference contributes ("the outfit from image 2", "the background of image 3"), not
+  just that it exists.
+- Plain prose, plain words — "image 1", "image 2". No brackets, tags, or markup.
+
+This endpoint is asynchronous: it answers with `request_id` and `status_url`, which you poll. Do
+not send `"sync": true` here — an instruction edit takes longer than a single response is allowed to
+take, so a synchronous request fails with a gateway timeout even though the job itself is fine.
+
+**Constraints** — each returns 422 with a readable message:
+- More than 4 images. Trim the set before sending; the request is refused, not truncated.
+- A `mask` together with 2 or more images (masked edits are single-image only).
+- 2 or more images together with a tailored `model_id` or `model_version: FIBO_BBQ` — both of those
+  run on the single-reference model.
+
+**Completed Result:**
+```json
+{
+  "status": "COMPLETED",
+  "result": {
+    "image_url": "https://...",
+    "seed": 1234,
+    "structured_prompt": "{...}",
+    "warning": null
+  }
+}
+```
+
+The result also carries the structured instruction the edit was rendered from — named
+`structured_prompt` on a polled result and `structured_instruction` on an inline `"sync": true`
+response. Read whichever is present.
+
+`warning` is set when a parameter was accepted but not honored — `aspect_ratio` on a single-image
+request, a supplied `model_version`, or a tuning parameter the serving model does not read. Relay it
+to the user rather than dropping it.
 
 ### POST /v2/image/edit/gen_fill
 

--- a/skills/bria-ai/references/code-examples/bria_client.sh
+++ b/skills/bria-ai/references/code-examples/bria_client.sh
@@ -8,6 +8,12 @@
 #   RESULT=$(bria_call /v2/image/edit/remove_background "/path/to/image.png")
 #   RESULT=$(bria_call /v2/image/edit/replace_background "https://example.com/img.jpg" '"prompt":"sunset beach"')
 #   RESULT=$(bria_call /v2/image/edit "/path/to/image.png" --key images '"instruction":"make it red"')
+#   RESULT=$(bria_call /v2/image/edit "https://example.com/man.jpg" --key images \
+#     --image "https://example.com/santa.png" \
+#     '"instruction":"dress the man in image 1 in the santa outfit from image 2"')
+#
+# Each extra --image adds the next reference image, in order: the positional image is "image 1",
+# the first --image is "image 2", and so on. Only the images array (--key images) takes references.
 #
 # BRIA_API_KEY is auto-loaded from ~/.bria/credentials if not already set.
 
@@ -15,13 +21,15 @@ BRIA_API_BASE="${BRIA_API_BASE:-https://engine.prod.bria-api.com}"
 BRIA_USER_AGENT="BriaSkills/1.3.5"
 
 bria_call() {
-  local endpoint image key extra payload result http_code body url status_url poll i
+  local endpoint image key extra payload result http_code body url status_url poll i img
+  local references=()
   endpoint="$1"; image="$2"; shift 2
 
   key="image"; extra=""
   while [ $# -gt 0 ]; do
     case "$1" in
       --key) key="$2"; shift 2 ;;
+      --image) references+=("$2"); shift 2 ;;
       *) extra="${extra:+$extra, }$1"; shift ;;
     esac
   done
@@ -36,25 +44,32 @@ bria_call() {
 
   if [ -z "$image" ]; then
     printf '{' > "$payload"
+  elif [ "$key" = "images" ]; then
+    # Written one entry at a time, in argument order: the array position is how the instruction
+    # addresses each image ("image 1", "image 2"), so nothing here may reorder them.
+    printf '{"images": [' > "$payload"
+    i=0
+    # ${arr[@]+"${arr[@]}"} expands to nothing for an empty array instead of failing under `set -u`.
+    for img in "$image" ${references[@]+"${references[@]}"}; do
+      [ "$i" -gt 0 ] && printf ', ' >> "$payload"
+      if printf '%s' "$img" | grep -qE '^https?://'; then
+        printf '"%s"' "$img" >> "$payload"
+      else
+        [ ! -f "$img" ] && { echo "ERROR: File not found: $img" >&2; return 1; }
+        printf '"' >> "$payload"
+        base64 < "$img" | tr -d '\n' >> "$payload"
+        printf '"' >> "$payload"
+      fi
+      i=$((i + 1))
+    done
+    printf ']' >> "$payload"
   elif printf '%s' "$image" | grep -qE '^https?://'; then
-    if [ "$key" = "images" ]; then
-      printf '{"images": ["%s"]' "$image" > "$payload"
-    else
-      printf '{"%s": "%s"' "$key" "$image" > "$payload"
-    fi
+    printf '{"%s": "%s"' "$key" "$image" > "$payload"
   else
     [ ! -f "$image" ] && { echo "ERROR: File not found: $image" >&2; return 1; }
-    if [ "$key" = "images" ]; then
-      printf '{"images": ["' > "$payload"
-    else
-      printf '{"%s": "' "$key" > "$payload"
-    fi
+    printf '{"%s": "' "$key" > "$payload"
     base64 < "$image" | tr -d '\n' >> "$payload"
-    if [ "$key" = "images" ]; then
-      printf '"]' >> "$payload"
-    else
-      printf '"' >> "$payload"
-    fi
+    printf '"' >> "$payload"
   fi
 
   if [ -n "$extra" ]; then


### PR DESCRIPTION
[BLD-179](https://bria-ai.atlassian.net/browse/BLD-179) — the public skill half. `/v2/image/edit`
now accepts 1–4 reference images, and the order they are sent in is how the instruction addresses
them. Stacked on [#58](https://github.com/Bria-AI/bria-skill/pull/58), which corrects unrelated
claims in the same reference file; merge that first and this retargets to `dev` on its own.

## Where this code actually runs

- Someone with the Bria skill installed in Claude Code (npm `bria-skills`, or the plugin
  marketplace) says "put this product into that kitchen photo" or "dress him in the outfit from
  this picture". The agent reads `SKILL.md` and `references/api-endpoints.md`, learns that `images`
  takes up to four entries and that the instruction refers to them as "image 1" and "image 2", and
  calls `bria_call /v2/image/edit "<first>" --key images --image "<second>" '"instruction": …'`.
- The same journey on the other two shipping surfaces: the kiro power (`kiro/bria-ai/POWER.md` plus
  its python, typescript and bash clients) and the OpenClaw plugin
  (`@galbria/bria-ai-openclaw`), whose docs and shell client get the same capability.
- Single-image editing — by far the common case today — is unchanged for every one of those users:
  the payload `bria_call` builds for one image is byte-identical to what it built before.

## What changed

- `references/api-endpoints.md`: the `POST /v2/image/edit` section is rewritten around the ordered
  `images` array — a multi-reference request example, the parameters that change agent behaviour
  (`seed`, `aspect_ratio` with its single-image caveat, `model_version` as deprecated-and-ignored),
  how to word a multi-reference instruction, the three 422s, and the response `warning` field.
  Applied to the canonical skill and both variants.
- `SKILL.md` (and `POWER.md`, and the OpenClaw skill and its capabilities reference): a
  multi-reference capability row, a two-image `bria_call` example, the `--image` convention, and a
  short passage on when to reach for a second image and how to word the instruction.
- `references/code-examples/bria_client.sh`: `bria_call` takes a repeatable `--image` flag that
  appends the next reference, in order. The kiro python, typescript and bash clients' edit methods
  accept several images the same way.
- `preambles/image-input-handling.md` documents the multi-image call alongside the single-image one.
## Decisions in this change

- **No version bump.** The bump belongs to the release commit when `dev` goes to `main`, so this
  branch leaves `package.json`, the plugin manifests, the skill front matter and `BRIA_USER_AGENT`
  alone. That keeps this PR to the 13 files that actually change behaviour instead of 44.
- **The variant re-sync is its own commit.** `kiro/` and `bria-ai-openclaw/` keep hand-maintained
  copies of `api-endpoints.md`; both had fallen 138 lines behind the canonical file. They were
  byte-identical to each other, so the first commit copies the canonical file over both and the
  second applies the multi-reference change once across all three.
- **`steps_num` and `guidance_scale` stay undocumented.** They were never documented on this
  endpoint, and multi-reference requests ignore them; documenting them as accepted-but-ignored
  would invite agents to send inert parameters.
- **`model_version` is described as deprecated and ignored**, because that is what the service does
  with it — every value except `FIBO_BBQ` is accepted, ignored, and reported back in `warning`.
- **Instructions are plain prose with 1-based positions** ("image 1", "image 2"), matching the
  pipeline's own convention. The bracketed `<image_N>` form belongs to the internal structured
  prompt layer and stays out of skill copy.
- **The edit endpoint is documented as polled**, never `"sync": true` — a synchronous edit exceeds
  what a single response is allowed to take and fails at the gateway.

## How this was checked

Thirty user-shaped asks were put to a fresh agent that had only this skill to work from, in an
isolated sandbox with the network replaced by a recorder, so what was graded is the request the
agent actually built rather than its account of itself. All ten multi-reference asks produced one
valid, correctly ordered call, each using the positional convention. The twenty others produced the
same call as the current skill, including all ten that belong on a dedicated endpoint — so the
expanded edit section does not pull specialised work onto `/v2/image/edit`. Three of the wording
changes here came out of those runs.

## Release dependency

Multi-image requests are gated on the PostHog flag
[`fibo-edit-1-5-enabled`](https://eu.posthog.com/project/85705/feature_flags/251758), currently
rolled out to the Bria organization only. Everything single-image here works today; the
multi-reference documentation describes what that flag turns on, so the release that carries it
wants to go out as the flag widens beyond Bria.
