### PR TITLE
fix: Correct endpoint reference claims against the current API (BLD-179)

### DIFF
--- a/bria-ai-openclaw/skills/bria-ai/SKILL.md
+++ b/bria-ai-openclaw/skills/bria-ai/SKILL.md
@@ -144,7 +144,7 @@ RESULT=$(bria_call /v2/image/edit/replace_background "https://example.com/img.jp
 RESULT=$(bria_call /v2/image/edit "/path/to/image.png" --key images '"instruction": "make it look warmer"')
 
 # Upscale
-RESULT=$(bria_call /v2/image/edit/increase_resolution "https://example.com/img.jpg" '"scale": 4')
+RESULT=$(bria_call /v2/image/edit/increase_resolution "https://example.com/img.jpg" '"desired_increase": 4')
 
 # Lifestyle shot
 RESULT=$(bria_call /v1/product/lifestyle_shot_by_text "/path/to/product.png" '"scene_description": "modern kitchen countertop"')

--- a/bria-ai-openclaw/skills/bria-ai/references/api-endpoints.md
+++ b/bria-ai-openclaw/skills/bria-ai/references/api-endpoints.md
@@ -255,7 +255,8 @@ Upscale image resolution.
 ```json
 {
   "image": "https://source-image-url",
-  "scale": 2
+  "desired_increase": 4,
+  "preserve_alpha": true
 }
 ```
 
@@ -264,7 +265,43 @@ Upscale image resolution.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `image` | string | required | Source image URL |
-| `scale` | int | 2 | Upscale factor (2 or 4) |
+| `desired_increase` | int | 2 | Upscale factor, range 2–4 |
+| `preserve_alpha` | bool | false | Preserve transparency. Set `true` when input has an alpha channel — the API upscales and recombines the alpha server-side, so you don't need to handle it client-side. |
+
+### POST /v1/product/cutout
+
+Remove the background from a product photo → clean transparent PNG. The `/v1/product/*` endpoints take `image_url` (URL) or `file` (base64).
+
+**Request:**
+```json
+{ "image_url": "https://…/raw.jpg" }
+```
+Response: `{ "result_url": "https://…png" }` (synchronous).
+
+### POST /v1/product/packshot
+
+Standardized 2000×2000 packshot on a solid/clean background.
+
+| Parameter | Type | Notes |
+|-----------|------|-------|
+| `image_url` / `file` | string | Product image (a cutout is recommended) |
+| `background_color` | string | Hex like `#FFFFFF`, or `transparent` |
+| `sku` | string | Optional label/id |
+
+Response: `{ "result_url": "…" }` (synchronous).
+
+### POST /v1/product/shadow
+
+Add a realistic shadow to a product cutout.
+
+| Parameter | Type | Notes |
+|-----------|------|-------|
+| `image_url` / `file` | string | Product cutout |
+| `type` | string | `regular` (drop) or `float` (elliptical) |
+| `background_color` | string | Hex or `transparent` |
+| `shadow_intensity` | int | 0–100 (approx) |
+
+Response: `{ "result_url": "…" }` (synchronous).
 
 ### POST /v1/product/lifestyle_shot_by_text
 
@@ -274,10 +311,38 @@ Place a product in a lifestyle scene using text description.
 ```json
 {
   "file": "BASE64_ENCODED_IMAGE",
-  "prompt": "modern kitchen countertop, natural lighting",
+  "scene_description": "modern kitchen countertop, natural lighting",
   "placement_type": "automatic"
 }
 ```
+
+**Parameters:**
+
+| Parameter | Type | Notes |
+|-----------|------|-------|
+| `image_url` / `file` | string | Product (cutout recommended) |
+| `scene_description` | string | Environment + lighting + mood |
+| `mode` | string | `base`, `high_control` (recommended), `fast` |
+| `placement_type` | string | `automatic`, `automatic_aspect_ratio`, `manual_placement`, `custom_coordinates`, `manual_padding`, `original` |
+| `aspect_ratio` | string | e.g. `1:1`, `4:5`, `16:9` (with `automatic_aspect_ratio`) |
+| `num_results` | int | Number of variations |
+| `sync` | bool | `true` returns results inline |
+| `optimize_description` | bool | Let Bria refine the prompt |
+
+Response: `{ "result": [[ "image_url", "seed", "session_id" ], …] }` — extract `result[0][0]`.
+
+### POST /v1/product/lifestyle_shot_by_image
+
+Same as `lifestyle_shot_by_text`, but the scene comes from a reference background image instead of a text description.
+
+| Parameter | Type | Notes |
+|-----------|------|-------|
+| `image_url` / `file` | string | Product |
+| `ref_image_urls` | array | One or more background reference URLs |
+| `placement_type` | string | see above |
+| `num_results` | int | variations |
+
+Response: `{ "result": [[ "image_url", … ], …] }`.
 
 ### POST /image/edit/product/integrate
 
@@ -333,6 +398,63 @@ Integrate and embed one or more products into a predefined scene at precise user
   "status_url": "https://..."
 }
 ```
+
+### POST /v2/image/edit/product_dimensions
+
+Render a marketplace-ready dimension image from a product photo: the background is removed automatically, then measurement callout lines + labels are drawn around the product, with an optional title and optional weight/capacity text. Three visual styles. Useful for e-commerce listings (Amazon-style "dimensions" images).
+
+**Request:**
+```json
+{
+  "image": "https://product-image-url",
+  "style": "default",
+  "dimensions": [
+    {"name": "height", "value": 12, "unit": "cm", "position": "left"},
+    {"name": "width_bottom", "value": 6, "unit": "cm", "position": "bottom"}
+  ],
+  "title": "Gummies Bottle",
+  "weight": {"value": 250, "unit": "g", "label": "Net Weight"},
+  "capacity": {"value": 500, "unit": "ml"},
+  "background": "white",
+  "output_format": "png"
+}
+```
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `image` | string | required | Product photo URL or base64. Background is removed automatically — no pre-cutout needed |
+| `dimensions` | array | required | One or more dimension callouts (min 1) |
+| `dimensions[].name` | string | required | `height`, `width_bottom`, or `width_top` (`length`/`depth` not currently enabled) |
+| `dimensions[].value` | float | required | Physical measurement value (must be > 0) |
+| `dimensions[].unit` | string | required | `mm`, `cm`, `m`, `in`, `"` (inches), `ft`, `'` (feet) |
+| `dimensions[].position` | string | per-name | Callout side: `top`, `bottom`, `left`, `right`. Defaults: height→`left`, width_bottom→`bottom`, width_top→`top` |
+| `style` | string | required | `default`, `childlike`, or `elegant` |
+| `units_display` | string | "single" | `single`, `dual_bullet`, `dual_slash`, `dual_parens`. For dual modes, supply two `dimensions` entries with the same `name`+`position` but different `unit` (e.g. `in` and `cm`) — they merge into one dual-unit label |
+| `background` | string | "white" | `white`, `cream`, `charcoal`, or a hex color (e.g. `#f5f0e8`) |
+| `title` | string | - | Optional headline above the product (max 80 chars) |
+| `title_position` | string | "top_center" | `top_left`, `top_center`, `top_right` |
+| `weight` | object | - | Optional weight callout below the product |
+| `weight.value` | float | required* | Weight value (> 0) *if `weight` is provided |
+| `weight.unit` | string | required* | `lb`, `oz`, `g`, `kg` |
+| `weight.label` | string | "Weight" | `Weight` or `Net Weight` |
+| `capacity` | object | - | Optional capacity callout below the product |
+| `capacity.value` | float | required* | Capacity value (> 0) *if `capacity` is provided |
+| `capacity.unit` | string | required* | `fl_oz`, `ml`, `l`, `qt`, `gal`, `cups` |
+| `output_format` | string | "png" | `png`, `jpeg`, or `dual` (composite PNG + a transparent overlay-only PNG, returned as two images) |
+| `output_size` | int | 2200 | Square output edge length in px (256–2200) |
+| `proportional_lines` | bool | true | Scale each dimension line's length to its measurement (the largest per axis spans the product) |
+
+**Async Response (202):**
+```json
+{
+  "request_id": "uuid",
+  "status_url": "https://..."
+}
+```
+
+Poll `status_url` for the result. `dual` output returns two images: `[composite, overlay]`.
 
 ---
 

--- a/bria-ai-openclaw/skills/bria-ai/references/api-endpoints.md
+++ b/bria-ai-openclaw/skills/bria-ai/references/api-endpoints.md
@@ -28,7 +28,6 @@ Generate images from text prompts using FIBO's structured prompt system.
   "aspect_ratio": "1:1",
   "resolution": "1MP",
   "negative_prompt": "string",
-  "num_results": 1,
   "seed": null
 }
 ```
@@ -38,22 +37,22 @@ Generate images from text prompts using FIBO's structured prompt system.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `prompt` | string | required* | Image description (* or use `structured_prompt`) |
-| `aspect_ratio` | string | "1:1" | "1:1", "4:3", "16:9", "3:4", "9:16" |
+| `aspect_ratio` | string | "1:1" | "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9" |
 | `resolution` | string | "1MP" | Output image resolution. "1MP" or "4MP". "4MP" improves image details, especially for photorealism, but increases latency by ~30 seconds. |
 | `negative_prompt` | string | - | What to exclude |
-| `num_results` | int | 1 | Number of images (1-4) |
 | `seed` | int | random | For reproducibility |
 | `structured_prompt` | string | - | JSON from previous generation (for refinement). Use with `prompt` to refine, or alone with `seed` to recreate. |
-| `image_url` | string | - | Reference image (for inspire mode) |
+| `images` | array | - | Reference image for inspire mode: an array holding one image URL or base64 string |
 
-**Input Combination Rules** (mutually exclusive):
+**Input Combinations** — at least one of `prompt`, `images` or `structured_prompt` is required:
 - `prompt` — Generate from text
-- `image_url` — Generate inspired by a reference image
-- `image_url` + `prompt` — Generate inspired by image, guided by text
+- `images` — Generate inspired by a reference image
+- `images` + `prompt` — Generate inspired by image, guided by text
 - `structured_prompt` + `seed` — Recreate a previous image exactly
 - `structured_prompt` + `prompt` + `seed` — Refine a previous image with new instructions
 
-All combinations support `aspect_ratio`, `negative_prompt`, `num_results`, and `seed`.
+All combinations support `aspect_ratio`, `negative_prompt` and `seed`. Note that `"sync": true`
+cannot be combined with `"resolution": "4MP"` — that pairing is rejected.
 
 **Response:**
 ```json
@@ -147,9 +146,7 @@ Generate content in a masked region (inpainting).
   "image": "https://source-image-url",
   "mask": "https://mask-image-url",
   "prompt": "what to generate",
-  "mask_type": "manual",
-  "negative_prompt": "string",
-  "num_results": 1
+  "mask_type": "manual"
 }
 ```
 
@@ -161,8 +158,6 @@ Generate content in a masked region (inpainting).
 | `mask` | string | required | Mask URL (white=edit, black=keep) |
 | `prompt` | string | required | What to generate in masked area |
 | `mask_type` | string | "manual" | "manual" or "automatic" |
-| `negative_prompt` | string | - | What to avoid |
-| `num_results` | int | 1 | Number of variations |
 
 **Mask Requirements:**
 - White pixels (255) = area to edit
@@ -233,7 +228,7 @@ Expand/outpaint an image to extend its boundaries.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `image` | string | required | Source image URL or base64 string |
-| `aspect_ratio` | string | required | Target ratio: "1:1", "4:3", "16:9", "3:4", "9:16" |
+| `aspect_ratio` | string \| float | - | Target ratio: "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", or a float. Omit it and pass `canvas_size` instead |
 | `prompt` | string | - | Optional - describe content to generate |
 
 ### POST /v2/image/edit/enhance
@@ -265,8 +260,8 @@ Upscale image resolution.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `image` | string | required | Source image URL |
-| `desired_increase` | int | 2 | Upscale factor, range 2–4 |
-| `preserve_alpha` | bool | false | Preserve transparency. Set `true` when input has an alpha channel — the API upscales and recombines the alpha server-side, so you don't need to handle it client-side. |
+| `desired_increase` | int | 2 | Upscale factor: 2 or 4 |
+| `preserve_alpha` | bool | true | Preserve transparency. Set `true` when input has an alpha channel — the API upscales and recombines the alpha server-side, so you don't need to handle it client-side. |
 
 ### POST /v1/product/cutout
 
@@ -344,7 +339,7 @@ Same as `lifestyle_shot_by_text`, but the scene comes from a reference backgroun
 
 Response: `{ "result": [[ "image_url", … ], …] }`.
 
-### POST /image/edit/product/integrate
+### POST /v2/image/edit/product/integrate
 
 Integrate and embed one or more products into a predefined scene at precise user-defined coordinates. The product is automatically matched to the scene's lighting, perspective, and aesthetics. Products are automatically cut out from their background as part of the pipeline.
 
@@ -399,9 +394,12 @@ Integrate and embed one or more products into a predefined scene at precise user
 }
 ```
 
-### POST /v2/image/edit/product_dimensions
+### POST /v2/image/edit/product/generate/dimensions
 
-Render a marketplace-ready dimension image from a product photo: the background is removed automatically, then measurement callout lines + labels are drawn around the product, with an optional title and optional weight/capacity text. Three visual styles. Useful for e-commerce listings (Amazon-style "dimensions" images).
+Render a marketplace-ready dimension image from a product photo. (The older
+`/v2/image/edit/product_dimensions` path still works but is deprecated — use this one.)
+
+How it works: the background is removed automatically, then measurement callout lines + labels are drawn around the product, with an optional title and optional weight/capacity text. Three visual styles. Useful for e-commerce listings (Amazon-style "dimensions" images).
 
 **Request:**
 ```json
@@ -508,8 +506,7 @@ Blend/merge images or apply textures.
 ```json
 {
   "image": "base64-or-url",
-  "overlay": "texture-or-art-url",
-  "instruction": "Place the art on the shirt, keep the art exactly the same"
+  "instruction": "Place the art from this image on the shirt, keep the art exactly the same"
 }
 ```
 
@@ -559,7 +556,7 @@ Modify the lighting setup of an image.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `image` | string | required | Source image URL or base64 |
-| `light_type` | string | required | Lighting preset (see values below) |
+| `light_type` | string | "soft overcast daylight lighting" | Lighting preset (see values below) |
 | `light_direction` | string | required | `front`, `side`, `bottom`, `top-down` |
 
 **Light Types:** `midday`, `blue hour light`, `low-angle sunlight`, `sunrise light`, `spotlight on subject`, `overcast light`, `soft overcast daylight lighting`, `cloud-filtered lighting`, `fog-diffused lighting`, `side lighting`, `moonlight lighting`, `starlight nighttime`, `soft bokeh lighting`, `harsh studio lighting`
@@ -575,8 +572,7 @@ Convert a sketch or line drawing to a photorealistic image.
 **Request:**
 ```json
 {
-  "image": "sketch-base64-or-url",
-  "prompt": "optional description"
+  "image": "sketch-base64-or-url"
 }
 ```
 
@@ -646,7 +642,7 @@ Check async request status.
 **Response:**
 ```json
 {
-  "status": "IN_PROGRESS | COMPLETED | FAILED",
+  "status": "IN_PROGRESS | COMPLETED | ERROR",
   "result": {
     "image_url": "https://..."
   },
@@ -657,7 +653,8 @@ Check async request status.
 **Status Values:**
 - `IN_PROGRESS` - Still processing
 - `COMPLETED` - Success, result available
-- `FAILED` - Error occurred
+- `ERROR` - The request failed (this is the literal value; there is no `FAILED`)
+- `UNKNOWN` - No such request id
 
 **Polling Pattern:**
 ```python
@@ -670,7 +667,7 @@ def poll(status_url, api_key, timeout=120):
         data = r.json()
         if data["status"] == "COMPLETED":
             return data["result"]["image_url"]
-        if data["status"] == "FAILED":
+        if data["status"] in ("ERROR", "UNKNOWN"):
             raise Exception(data.get("error"))
         time.sleep(2)
     raise TimeoutError()

--- a/bria-ai-openclaw/skills/bria-ai/references/capabilities.md
+++ b/bria-ai-openclaw/skills/bria-ai/references/capabilities.md
@@ -18,11 +18,11 @@
 |------|------------|----------|
 | Generate images from text | FIBO Generate | `/v2/image/generate` |
 | Edit images by text instruction | FIBO-Edit | `/v2/image/edit` |
-| Edit image region with mask | GenFill/Erase | `/v2/image/edit/genfill` |
+| Edit image region with mask | GenFill/Erase | `/v2/image/edit/gen_fill` |
 | Add/Replace/Remove objects | Text-based editing | `/v2/image/edit` |
 | Remove background (transparent PNG) | RMBG-2.0 | `/v2/image/edit/remove_background` |
 | Replace/blur/erase background | Background ops | `/v2/image/edit/replace_background` |
-| Expand/outpaint images | Outpainting | `/v2/image/edit/increase_outpaint` |
+| Expand/outpaint images | Outpainting | `/v2/image/edit/expand` |
 | Upscale image resolution | Super Resolution | `/v2/image/edit/increase_resolution` |
 | Enhance image quality | Enhancement | `/v2/image/edit/enhance` |
 | Restyle images | Restyle | `/v2/image/edit/restyle` |
@@ -31,9 +31,9 @@
 | Composite/blend images | Image Blending | `/v2/image/edit/blend` |
 | Restore old photos | Restoration | `/v2/image/edit/restore` |
 | Colorize images | Colorization | `/v2/image/edit/colorize` |
-| Sketch to photo | Sketch2Image | `/v2/image/edit/sketch2image` |
+| Sketch to photo | Sketch2Image | `/v2/image/edit/sketch_to_colored_image` |
 | Create product lifestyle shots | Lifestyle Shot | `/v1/product/lifestyle_shot_by_text` |
-| Integrate products into scenes | Product Integrate | `/v1/product/product_integrate` |
+| Integrate products into scenes | Product Integrate | `/v2/image/edit/product/integrate` |
 
 ---
 

--- a/kiro/bria-ai/POWER.md
+++ b/kiro/bria-ai/POWER.md
@@ -188,7 +188,7 @@ RESULT=$(bria_call /v2/image/edit/replace_background "https://example.com/img.jp
 RESULT=$(bria_call /v2/image/edit "/path/to/image.png" --key images '"instruction": "make it look warmer"')
 
 # Upscale
-RESULT=$(bria_call /v2/image/edit/increase_resolution "https://example.com/img.jpg" '"scale": 4')
+RESULT=$(bria_call /v2/image/edit/increase_resolution "https://example.com/img.jpg" '"desired_increase": 4')
 
 # Lifestyle shot
 RESULT=$(bria_call /v1/product/lifestyle_shot_by_text "/path/to/product.png" '"scene_description": "modern kitchen countertop"')

--- a/kiro/bria-ai/steering/api-endpoints.md
+++ b/kiro/bria-ai/steering/api-endpoints.md
@@ -255,7 +255,8 @@ Upscale image resolution.
 ```json
 {
   "image": "https://source-image-url",
-  "scale": 2
+  "desired_increase": 4,
+  "preserve_alpha": true
 }
 ```
 
@@ -264,7 +265,43 @@ Upscale image resolution.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `image` | string | required | Source image URL |
-| `scale` | int | 2 | Upscale factor (2 or 4) |
+| `desired_increase` | int | 2 | Upscale factor, range 2–4 |
+| `preserve_alpha` | bool | false | Preserve transparency. Set `true` when input has an alpha channel — the API upscales and recombines the alpha server-side, so you don't need to handle it client-side. |
+
+### POST /v1/product/cutout
+
+Remove the background from a product photo → clean transparent PNG. The `/v1/product/*` endpoints take `image_url` (URL) or `file` (base64).
+
+**Request:**
+```json
+{ "image_url": "https://…/raw.jpg" }
+```
+Response: `{ "result_url": "https://…png" }` (synchronous).
+
+### POST /v1/product/packshot
+
+Standardized 2000×2000 packshot on a solid/clean background.
+
+| Parameter | Type | Notes |
+|-----------|------|-------|
+| `image_url` / `file` | string | Product image (a cutout is recommended) |
+| `background_color` | string | Hex like `#FFFFFF`, or `transparent` |
+| `sku` | string | Optional label/id |
+
+Response: `{ "result_url": "…" }` (synchronous).
+
+### POST /v1/product/shadow
+
+Add a realistic shadow to a product cutout.
+
+| Parameter | Type | Notes |
+|-----------|------|-------|
+| `image_url` / `file` | string | Product cutout |
+| `type` | string | `regular` (drop) or `float` (elliptical) |
+| `background_color` | string | Hex or `transparent` |
+| `shadow_intensity` | int | 0–100 (approx) |
+
+Response: `{ "result_url": "…" }` (synchronous).
 
 ### POST /v1/product/lifestyle_shot_by_text
 
@@ -274,10 +311,38 @@ Place a product in a lifestyle scene using text description.
 ```json
 {
   "file": "BASE64_ENCODED_IMAGE",
-  "prompt": "modern kitchen countertop, natural lighting",
+  "scene_description": "modern kitchen countertop, natural lighting",
   "placement_type": "automatic"
 }
 ```
+
+**Parameters:**
+
+| Parameter | Type | Notes |
+|-----------|------|-------|
+| `image_url` / `file` | string | Product (cutout recommended) |
+| `scene_description` | string | Environment + lighting + mood |
+| `mode` | string | `base`, `high_control` (recommended), `fast` |
+| `placement_type` | string | `automatic`, `automatic_aspect_ratio`, `manual_placement`, `custom_coordinates`, `manual_padding`, `original` |
+| `aspect_ratio` | string | e.g. `1:1`, `4:5`, `16:9` (with `automatic_aspect_ratio`) |
+| `num_results` | int | Number of variations |
+| `sync` | bool | `true` returns results inline |
+| `optimize_description` | bool | Let Bria refine the prompt |
+
+Response: `{ "result": [[ "image_url", "seed", "session_id" ], …] }` — extract `result[0][0]`.
+
+### POST /v1/product/lifestyle_shot_by_image
+
+Same as `lifestyle_shot_by_text`, but the scene comes from a reference background image instead of a text description.
+
+| Parameter | Type | Notes |
+|-----------|------|-------|
+| `image_url` / `file` | string | Product |
+| `ref_image_urls` | array | One or more background reference URLs |
+| `placement_type` | string | see above |
+| `num_results` | int | variations |
+
+Response: `{ "result": [[ "image_url", … ], …] }`.
 
 ### POST /image/edit/product/integrate
 
@@ -333,6 +398,63 @@ Integrate and embed one or more products into a predefined scene at precise user
   "status_url": "https://..."
 }
 ```
+
+### POST /v2/image/edit/product_dimensions
+
+Render a marketplace-ready dimension image from a product photo: the background is removed automatically, then measurement callout lines + labels are drawn around the product, with an optional title and optional weight/capacity text. Three visual styles. Useful for e-commerce listings (Amazon-style "dimensions" images).
+
+**Request:**
+```json
+{
+  "image": "https://product-image-url",
+  "style": "default",
+  "dimensions": [
+    {"name": "height", "value": 12, "unit": "cm", "position": "left"},
+    {"name": "width_bottom", "value": 6, "unit": "cm", "position": "bottom"}
+  ],
+  "title": "Gummies Bottle",
+  "weight": {"value": 250, "unit": "g", "label": "Net Weight"},
+  "capacity": {"value": 500, "unit": "ml"},
+  "background": "white",
+  "output_format": "png"
+}
+```
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `image` | string | required | Product photo URL or base64. Background is removed automatically — no pre-cutout needed |
+| `dimensions` | array | required | One or more dimension callouts (min 1) |
+| `dimensions[].name` | string | required | `height`, `width_bottom`, or `width_top` (`length`/`depth` not currently enabled) |
+| `dimensions[].value` | float | required | Physical measurement value (must be > 0) |
+| `dimensions[].unit` | string | required | `mm`, `cm`, `m`, `in`, `"` (inches), `ft`, `'` (feet) |
+| `dimensions[].position` | string | per-name | Callout side: `top`, `bottom`, `left`, `right`. Defaults: height→`left`, width_bottom→`bottom`, width_top→`top` |
+| `style` | string | required | `default`, `childlike`, or `elegant` |
+| `units_display` | string | "single" | `single`, `dual_bullet`, `dual_slash`, `dual_parens`. For dual modes, supply two `dimensions` entries with the same `name`+`position` but different `unit` (e.g. `in` and `cm`) — they merge into one dual-unit label |
+| `background` | string | "white" | `white`, `cream`, `charcoal`, or a hex color (e.g. `#f5f0e8`) |
+| `title` | string | - | Optional headline above the product (max 80 chars) |
+| `title_position` | string | "top_center" | `top_left`, `top_center`, `top_right` |
+| `weight` | object | - | Optional weight callout below the product |
+| `weight.value` | float | required* | Weight value (> 0) *if `weight` is provided |
+| `weight.unit` | string | required* | `lb`, `oz`, `g`, `kg` |
+| `weight.label` | string | "Weight" | `Weight` or `Net Weight` |
+| `capacity` | object | - | Optional capacity callout below the product |
+| `capacity.value` | float | required* | Capacity value (> 0) *if `capacity` is provided |
+| `capacity.unit` | string | required* | `fl_oz`, `ml`, `l`, `qt`, `gal`, `cups` |
+| `output_format` | string | "png" | `png`, `jpeg`, or `dual` (composite PNG + a transparent overlay-only PNG, returned as two images) |
+| `output_size` | int | 2200 | Square output edge length in px (256–2200) |
+| `proportional_lines` | bool | true | Scale each dimension line's length to its measurement (the largest per axis spans the product) |
+
+**Async Response (202):**
+```json
+{
+  "request_id": "uuid",
+  "status_url": "https://..."
+}
+```
+
+Poll `status_url` for the result. `dual` output returns two images: `[composite, overlay]`.
 
 ---
 

--- a/kiro/bria-ai/steering/api-endpoints.md
+++ b/kiro/bria-ai/steering/api-endpoints.md
@@ -28,7 +28,6 @@ Generate images from text prompts using FIBO's structured prompt system.
   "aspect_ratio": "1:1",
   "resolution": "1MP",
   "negative_prompt": "string",
-  "num_results": 1,
   "seed": null
 }
 ```
@@ -38,22 +37,22 @@ Generate images from text prompts using FIBO's structured prompt system.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `prompt` | string | required* | Image description (* or use `structured_prompt`) |
-| `aspect_ratio` | string | "1:1" | "1:1", "4:3", "16:9", "3:4", "9:16" |
+| `aspect_ratio` | string | "1:1" | "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9" |
 | `resolution` | string | "1MP" | Output image resolution. "1MP" or "4MP". "4MP" improves image details, especially for photorealism, but increases latency by ~30 seconds. |
 | `negative_prompt` | string | - | What to exclude |
-| `num_results` | int | 1 | Number of images (1-4) |
 | `seed` | int | random | For reproducibility |
 | `structured_prompt` | string | - | JSON from previous generation (for refinement). Use with `prompt` to refine, or alone with `seed` to recreate. |
-| `image_url` | string | - | Reference image (for inspire mode) |
+| `images` | array | - | Reference image for inspire mode: an array holding one image URL or base64 string |
 
-**Input Combination Rules** (mutually exclusive):
+**Input Combinations** — at least one of `prompt`, `images` or `structured_prompt` is required:
 - `prompt` — Generate from text
-- `image_url` — Generate inspired by a reference image
-- `image_url` + `prompt` — Generate inspired by image, guided by text
+- `images` — Generate inspired by a reference image
+- `images` + `prompt` — Generate inspired by image, guided by text
 - `structured_prompt` + `seed` — Recreate a previous image exactly
 - `structured_prompt` + `prompt` + `seed` — Refine a previous image with new instructions
 
-All combinations support `aspect_ratio`, `negative_prompt`, `num_results`, and `seed`.
+All combinations support `aspect_ratio`, `negative_prompt` and `seed`. Note that `"sync": true`
+cannot be combined with `"resolution": "4MP"` — that pairing is rejected.
 
 **Response:**
 ```json
@@ -147,9 +146,7 @@ Generate content in a masked region (inpainting).
   "image": "https://source-image-url",
   "mask": "https://mask-image-url",
   "prompt": "what to generate",
-  "mask_type": "manual",
-  "negative_prompt": "string",
-  "num_results": 1
+  "mask_type": "manual"
 }
 ```
 
@@ -161,8 +158,6 @@ Generate content in a masked region (inpainting).
 | `mask` | string | required | Mask URL (white=edit, black=keep) |
 | `prompt` | string | required | What to generate in masked area |
 | `mask_type` | string | "manual" | "manual" or "automatic" |
-| `negative_prompt` | string | - | What to avoid |
-| `num_results` | int | 1 | Number of variations |
 
 **Mask Requirements:**
 - White pixels (255) = area to edit
@@ -233,7 +228,7 @@ Expand/outpaint an image to extend its boundaries.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `image` | string | required | Source image URL or base64 string |
-| `aspect_ratio` | string | required | Target ratio: "1:1", "4:3", "16:9", "3:4", "9:16" |
+| `aspect_ratio` | string \| float | - | Target ratio: "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", or a float. Omit it and pass `canvas_size` instead |
 | `prompt` | string | - | Optional - describe content to generate |
 
 ### POST /v2/image/edit/enhance
@@ -265,8 +260,8 @@ Upscale image resolution.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `image` | string | required | Source image URL |
-| `desired_increase` | int | 2 | Upscale factor, range 2–4 |
-| `preserve_alpha` | bool | false | Preserve transparency. Set `true` when input has an alpha channel — the API upscales and recombines the alpha server-side, so you don't need to handle it client-side. |
+| `desired_increase` | int | 2 | Upscale factor: 2 or 4 |
+| `preserve_alpha` | bool | true | Preserve transparency. Set `true` when input has an alpha channel — the API upscales and recombines the alpha server-side, so you don't need to handle it client-side. |
 
 ### POST /v1/product/cutout
 
@@ -344,7 +339,7 @@ Same as `lifestyle_shot_by_text`, but the scene comes from a reference backgroun
 
 Response: `{ "result": [[ "image_url", … ], …] }`.
 
-### POST /image/edit/product/integrate
+### POST /v2/image/edit/product/integrate
 
 Integrate and embed one or more products into a predefined scene at precise user-defined coordinates. The product is automatically matched to the scene's lighting, perspective, and aesthetics. Products are automatically cut out from their background as part of the pipeline.
 
@@ -399,9 +394,12 @@ Integrate and embed one or more products into a predefined scene at precise user
 }
 ```
 
-### POST /v2/image/edit/product_dimensions
+### POST /v2/image/edit/product/generate/dimensions
 
-Render a marketplace-ready dimension image from a product photo: the background is removed automatically, then measurement callout lines + labels are drawn around the product, with an optional title and optional weight/capacity text. Three visual styles. Useful for e-commerce listings (Amazon-style "dimensions" images).
+Render a marketplace-ready dimension image from a product photo. (The older
+`/v2/image/edit/product_dimensions` path still works but is deprecated — use this one.)
+
+How it works: the background is removed automatically, then measurement callout lines + labels are drawn around the product, with an optional title and optional weight/capacity text. Three visual styles. Useful for e-commerce listings (Amazon-style "dimensions" images).
 
 **Request:**
 ```json
@@ -508,8 +506,7 @@ Blend/merge images or apply textures.
 ```json
 {
   "image": "base64-or-url",
-  "overlay": "texture-or-art-url",
-  "instruction": "Place the art on the shirt, keep the art exactly the same"
+  "instruction": "Place the art from this image on the shirt, keep the art exactly the same"
 }
 ```
 
@@ -559,7 +556,7 @@ Modify the lighting setup of an image.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `image` | string | required | Source image URL or base64 |
-| `light_type` | string | required | Lighting preset (see values below) |
+| `light_type` | string | "soft overcast daylight lighting" | Lighting preset (see values below) |
 | `light_direction` | string | required | `front`, `side`, `bottom`, `top-down` |
 
 **Light Types:** `midday`, `blue hour light`, `low-angle sunlight`, `sunrise light`, `spotlight on subject`, `overcast light`, `soft overcast daylight lighting`, `cloud-filtered lighting`, `fog-diffused lighting`, `side lighting`, `moonlight lighting`, `starlight nighttime`, `soft bokeh lighting`, `harsh studio lighting`
@@ -575,8 +572,7 @@ Convert a sketch or line drawing to a photorealistic image.
 **Request:**
 ```json
 {
-  "image": "sketch-base64-or-url",
-  "prompt": "optional description"
+  "image": "sketch-base64-or-url"
 }
 ```
 
@@ -646,7 +642,7 @@ Check async request status.
 **Response:**
 ```json
 {
-  "status": "IN_PROGRESS | COMPLETED | FAILED",
+  "status": "IN_PROGRESS | COMPLETED | ERROR",
   "result": {
     "image_url": "https://..."
   },
@@ -657,7 +653,8 @@ Check async request status.
 **Status Values:**
 - `IN_PROGRESS` - Still processing
 - `COMPLETED` - Success, result available
-- `FAILED` - Error occurred
+- `ERROR` - The request failed (this is the literal value; there is no `FAILED`)
+- `UNKNOWN` - No such request id
 
 **Polling Pattern:**
 ```python
@@ -670,7 +667,7 @@ def poll(status_url, api_key, timeout=120):
         data = r.json()
         if data["status"] == "COMPLETED":
             return data["result"]["image_url"]
-        if data["status"] == "FAILED":
+        if data["status"] in ("ERROR", "UNKNOWN"):
             raise Exception(data.get("error"))
         time.sleep(2)
     raise TimeoutError()

--- a/skills/bria-ai/SKILL.md
+++ b/skills/bria-ai/SKILL.md
@@ -193,7 +193,7 @@ RESULT=$(bria_call /v2/image/edit/replace_background "https://example.com/img.jp
 # Edit image (uses images array — pass --key images)
 RESULT=$(bria_call /v2/image/edit "/path/to/image.png" --key images '"instruction": "make it look warmer"')
 
-# Upscale (use `desired_increase`, range 2-4. Add `"preserve_alpha": true` for transparent inputs)
+# Upscale (`desired_increase` is 2 or 4 — no other value. Transparency is preserved by default)
 RESULT=$(bria_call /v2/image/edit/increase_resolution "https://example.com/img.jpg" '"desired_increase": 4')
 
 # Product cutout → transparent PNG (use --key file for a local image)

--- a/skills/bria-ai/references/api-endpoints.md
+++ b/skills/bria-ai/references/api-endpoints.md
@@ -28,7 +28,6 @@ Generate images from text prompts using FIBO's structured prompt system.
   "aspect_ratio": "1:1",
   "resolution": "1MP",
   "negative_prompt": "string",
-  "num_results": 1,
   "seed": null
 }
 ```
@@ -38,22 +37,22 @@ Generate images from text prompts using FIBO's structured prompt system.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `prompt` | string | required* | Image description (* or use `structured_prompt`) |
-| `aspect_ratio` | string | "1:1" | "1:1", "4:3", "16:9", "3:4", "9:16" |
+| `aspect_ratio` | string | "1:1" | "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9" |
 | `resolution` | string | "1MP" | Output image resolution. "1MP" or "4MP". "4MP" improves image details, especially for photorealism, but increases latency by ~30 seconds. |
 | `negative_prompt` | string | - | What to exclude |
-| `num_results` | int | 1 | Number of images (1-4) |
 | `seed` | int | random | For reproducibility |
 | `structured_prompt` | string | - | JSON from previous generation (for refinement). Use with `prompt` to refine, or alone with `seed` to recreate. |
-| `image_url` | string | - | Reference image (for inspire mode) |
+| `images` | array | - | Reference image for inspire mode: an array holding one image URL or base64 string |
 
-**Input Combination Rules** (mutually exclusive):
+**Input Combinations** — at least one of `prompt`, `images` or `structured_prompt` is required:
 - `prompt` — Generate from text
-- `image_url` — Generate inspired by a reference image
-- `image_url` + `prompt` — Generate inspired by image, guided by text
+- `images` — Generate inspired by a reference image
+- `images` + `prompt` — Generate inspired by image, guided by text
 - `structured_prompt` + `seed` — Recreate a previous image exactly
 - `structured_prompt` + `prompt` + `seed` — Refine a previous image with new instructions
 
-All combinations support `aspect_ratio`, `negative_prompt`, `num_results`, and `seed`.
+All combinations support `aspect_ratio`, `negative_prompt` and `seed`. Note that `"sync": true`
+cannot be combined with `"resolution": "4MP"` — that pairing is rejected.
 
 **Response:**
 ```json
@@ -147,9 +146,7 @@ Generate content in a masked region (inpainting).
   "image": "https://source-image-url",
   "mask": "https://mask-image-url",
   "prompt": "what to generate",
-  "mask_type": "manual",
-  "negative_prompt": "string",
-  "num_results": 1
+  "mask_type": "manual"
 }
 ```
 
@@ -161,8 +158,6 @@ Generate content in a masked region (inpainting).
 | `mask` | string | required | Mask URL (white=edit, black=keep) |
 | `prompt` | string | required | What to generate in masked area |
 | `mask_type` | string | "manual" | "manual" or "automatic" |
-| `negative_prompt` | string | - | What to avoid |
-| `num_results` | int | 1 | Number of variations |
 
 **Mask Requirements:**
 - White pixels (255) = area to edit
@@ -233,7 +228,7 @@ Expand/outpaint an image to extend its boundaries.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `image` | string | required | Source image URL or base64 string |
-| `aspect_ratio` | string | required | Target ratio: "1:1", "4:3", "16:9", "3:4", "9:16" |
+| `aspect_ratio` | string \| float | - | Target ratio: "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", or a float. Omit it and pass `canvas_size` instead |
 | `prompt` | string | - | Optional - describe content to generate |
 
 ### POST /v2/image/edit/enhance
@@ -265,8 +260,8 @@ Upscale image resolution.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `image` | string | required | Source image URL |
-| `desired_increase` | int | 2 | Upscale factor, range 2–4 |
-| `preserve_alpha` | bool | false | Preserve transparency. Set `true` when input has an alpha channel — the API upscales and recombines the alpha server-side, so you don't need to handle it client-side. |
+| `desired_increase` | int | 2 | Upscale factor: 2 or 4 |
+| `preserve_alpha` | bool | true | Preserve transparency. Set `true` when input has an alpha channel — the API upscales and recombines the alpha server-side, so you don't need to handle it client-side. |
 
 ### POST /v1/product/cutout
 
@@ -344,7 +339,7 @@ Same as `lifestyle_shot_by_text`, but the scene comes from a reference backgroun
 
 Response: `{ "result": [[ "image_url", … ], …] }`.
 
-### POST /image/edit/product/integrate
+### POST /v2/image/edit/product/integrate
 
 Integrate and embed one or more products into a predefined scene at precise user-defined coordinates. The product is automatically matched to the scene's lighting, perspective, and aesthetics. Products are automatically cut out from their background as part of the pipeline.
 
@@ -399,9 +394,12 @@ Integrate and embed one or more products into a predefined scene at precise user
 }
 ```
 
-### POST /v2/image/edit/product_dimensions
+### POST /v2/image/edit/product/generate/dimensions
 
-Render a marketplace-ready dimension image from a product photo: the background is removed automatically, then measurement callout lines + labels are drawn around the product, with an optional title and optional weight/capacity text. Three visual styles. Useful for e-commerce listings (Amazon-style "dimensions" images).
+Render a marketplace-ready dimension image from a product photo. (The older
+`/v2/image/edit/product_dimensions` path still works but is deprecated — use this one.)
+
+How it works: the background is removed automatically, then measurement callout lines + labels are drawn around the product, with an optional title and optional weight/capacity text. Three visual styles. Useful for e-commerce listings (Amazon-style "dimensions" images).
 
 **Request:**
 ```json
@@ -508,8 +506,7 @@ Blend/merge images or apply textures.
 ```json
 {
   "image": "base64-or-url",
-  "overlay": "texture-or-art-url",
-  "instruction": "Place the art on the shirt, keep the art exactly the same"
+  "instruction": "Place the art from this image on the shirt, keep the art exactly the same"
 }
 ```
 
@@ -559,7 +556,7 @@ Modify the lighting setup of an image.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `image` | string | required | Source image URL or base64 |
-| `light_type` | string | required | Lighting preset (see values below) |
+| `light_type` | string | "soft overcast daylight lighting" | Lighting preset (see values below) |
 | `light_direction` | string | required | `front`, `side`, `bottom`, `top-down` |
 
 **Light Types:** `midday`, `blue hour light`, `low-angle sunlight`, `sunrise light`, `spotlight on subject`, `overcast light`, `soft overcast daylight lighting`, `cloud-filtered lighting`, `fog-diffused lighting`, `side lighting`, `moonlight lighting`, `starlight nighttime`, `soft bokeh lighting`, `harsh studio lighting`
@@ -575,8 +572,7 @@ Convert a sketch or line drawing to a photorealistic image.
 **Request:**
 ```json
 {
-  "image": "sketch-base64-or-url",
-  "prompt": "optional description"
+  "image": "sketch-base64-or-url"
 }
 ```
 
@@ -646,7 +642,7 @@ Check async request status.
 **Response:**
 ```json
 {
-  "status": "IN_PROGRESS | COMPLETED | FAILED",
+  "status": "IN_PROGRESS | COMPLETED | ERROR",
   "result": {
     "image_url": "https://..."
   },
@@ -657,7 +653,8 @@ Check async request status.
 **Status Values:**
 - `IN_PROGRESS` - Still processing
 - `COMPLETED` - Success, result available
-- `FAILED` - Error occurred
+- `ERROR` - The request failed (this is the literal value; there is no `FAILED`)
+- `UNKNOWN` - No such request id
 
 **Polling Pattern:**
 ```python
@@ -670,7 +667,7 @@ def poll(status_url, api_key, timeout=120):
         data = r.json()
         if data["status"] == "COMPLETED":
             return data["result"]["image_url"]
-        if data["status"] == "FAILED":
+        if data["status"] in ("ERROR", "UNKNOWN"):
             raise Exception(data.get("error"))
         time.sleep(2)
     raise TimeoutError()


### PR DESCRIPTION
Corrections to the Bria endpoint reference in this repo. No new capability, no behaviour change and
no version bump — every edit here brings a documented claim back in line with what the API already
does. Split out of the multi-reference work ([#57](https://github.com/Bria-AI/bria-skill/pull/57))
so that PR carries only the feature.

## Where this code actually runs

- An agent with this skill installed is told, in `references/api-endpoints.md`, which endpoint to
  call and which fields to send. Where that file was wrong the agent built a request the service
  refuses or silently ignores — and it had no way to know, because the doc is its only source.
- Four of these are hard failures a user sees as "it didn't work": three endpoint paths in the
  OpenClaw capability table that do not exist, and `product/integrate` documented without its `/v2`
  prefix.
- The rest are quieter. A parameter the endpoint has no field for is accepted and dropped, so the
  call succeeds and the result ignores what was asked for. `blend`'s `overlay` is the worst of
  these: an agent told to composite two images sends the second one in a field nothing reads, and
  gets back a plausible picture generated from the text alone.
- The polling example in the reference tested for a job status the API never returns, so a failed
  job looked like a job still running until the loop timed out.

## What was wrong, and what it is now

Checked against the service's own route registrations and Pydantic input models, not against the
previous copy of these docs.

| Endpoint | Documented | Actually |
|---|---|---|
| `/v2/image/generate` | `image_url` for the reference image; `num_results` 1–4; five aspect ratios; input combinations "mutually exclusive" | `images` (an array, capped at one); no `num_results` field at all; nine aspect ratios; at least one of prompt/images/structured_prompt required, nothing exclusive. `sync` cannot be combined with `4MP` |
| `/v2/image/edit/gen_fill` | `num_results`, and `negative_prompt` as "what to avoid" | Neither is honoured — the model defines no `num_results`, and a supplied `negative_prompt` is overwritten server-side |
| `/v2/image/edit/expand` | `aspect_ratio` required, five values | Optional, nine ratios or a float; `canvas_size` is the alternative |
| `/v2/image/edit/increase_resolution` | `desired_increase` "range 2–4"; `preserve_alpha` default false | An enum of 2 or 4 — 3 is rejected; `preserve_alpha` defaults to **true** |
| `/v2/image/edit/blend` | `image`, `overlay`, `instruction` | No `overlay` field exists; the endpoint takes one image and an instruction |
| `/v2/image/edit/sketch_to_colored_image` | optional `prompt` | No `prompt` field exists |
| `/v2/image/edit/relight` | `light_type` required | Has a default; only `light_direction` is required |
| `/image/edit/product/integrate` | that path | Served at `/v2/image/edit/product/integrate` — the router gained its `/v2` prefix the day after the endpoint shipped |
| `/v2/image/edit/product_dimensions` | the only path | Marked deprecated; the current path is `/v2/image/edit/product/generate/dimensions`, with the old one kept as an alias |
| `GET /v2/status/{id}` | `IN_PROGRESS \| COMPLETED \| FAILED` | A failed job reports `ERROR`; an unknown id reports `UNKNOWN`. There is no `FAILED` |

And in the variants:

- The OpenClaw capability table pointed at `/v2/image/edit/genfill`, `/v2/image/edit/increase_outpaint`,
  `/v2/image/edit/sketch2image` and `/v1/product/product_integrate`. None of the four has ever been a
  route: the real names are `gen_fill` (since July 2025), `expand` (since July 2025),
  `sketch_to_colored_image` (since January 2026) and `/v2/image/edit/product/integrate`. That file is
  only read by the OpenClaw variant, so these never reached Claude Code or Kiro users.
- The kiro and openclaw upscale examples still passed `scale`, renamed to `desired_increase` in the
  canonical skill in March.

## Decisions in this change

- **The variant re-sync is its own commit.** `kiro/` and `bria-ai-openclaw/` keep hand-maintained
  copies of `api-endpoints.md` that had fallen 138 lines behind canonical. They were byte-identical
  to each other, so the first commit copies canonical over both, and the corrections then apply once
  across all three.
- **Two claims were left alone deliberately.** The generate section keeps `negative_prompt`, because
  unlike the edit path it is not inert everywhere — base generation ignores it with a notice while
  tailored generation honours it. And "Supported Image Formats" stays as written: no code enforces
  that allow-list, so replacing it would swap one unverified claim for another.
- **`steps_num` and `guidance_scale` stay undocumented** on the edit endpoints, as before.
- **No version bump.** That belongs to the release commit when `dev` goes to `main`.
