### PR TITLE
chore: disable CodeRabbit automatic reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# Disable CodeRabbit automatic reviews for this repo. CodeRabbit will no longer
+# auto-review or summarize pull requests; it only acts if explicitly invoked with
+# an @coderabbitai mention. To turn it off completely (including mentions), remove
+# this repo from the CodeRabbit GitHub App installation in the org settings.
+reviews:
+  auto_review:
+    enabled: false


### PR DESCRIPTION
Adds `.coderabbit.yaml` that disables CodeRabbit's automatic PR reviews:

```yaml
reviews:
  auto_review:
    enabled: false
```

After this merges to `main`, CodeRabbit stops auto-reviewing and summarizing PRs. It will still respond if someone explicitly `@coderabbitai`-mentions it.

To disable it **completely** (including mentions), remove `bria-skill` from the CodeRabbit GitHub App installation: Org settings → GitHub Apps → CodeRabbit → Configure → uncheck this repo (or toggle it off in the CodeRabbit dashboard). That's an org-admin action outside this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)