### PR TITLE
ci: update docs-sync gh secrets

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -24,9 +24,9 @@ name: Docs Sync
 #   DOCS_SYNC_SLACK_CHANNEL - Slack channel ID to notify (e.g. C0XXXXXXXXX).
 #
 # Required repo (or org) secrets:
-#   DEVOPS_PAT_TOKEN    - PAT with write access to the docs repo (push branch + open PR).
-#   ANTHROPIC_API_KEY   - Anthropic API key for the Claude Code action.
-#   BRIA_SLACKBOT_TOKEN - Slack bot token (xoxb-, needs chat:write; bot invited to the channel).
+#   RELEASE_TOKEN            - PAT with write access to the docs repo (push branch + open PR).
+#   ANTHROPIC_SKILLS_API_KEY - Anthropic API key for the Claude Code action.
+#   BRIA_SLACKBOT_TOKEN      - Slack bot token (xoxb-, needs chat:write; bot invited to the channel).
 
 on:
   pull_request:
@@ -61,6 +61,6 @@ jobs:
           ("Bria AI Skills"); update the skills list, capabilities, install steps, and links
           there to match the source, following its existing style.
     secrets:
-      docs_repo_token: ${{ secrets.DEVOPS_PAT_TOKEN }}
-      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+      docs_repo_token: ${{ secrets.RELEASE_TOKEN }}
+      anthropic_api_key: ${{ secrets.ANTHROPIC_SKILLS_API_KEY }}
       slack_bot_token: ${{ secrets.BRIA_SLACKBOT_TOKEN }}


### PR DESCRIPTION
Follow-up to #60. That PR merged with placeholder secret names; this points the docs-sync workflow at the secrets actually configured for this repo:

| Input | Secret |
|---|---|
| `docs_repo_token` | `RELEASE_TOKEN` |
| `anthropic_api_key` | `ANTHROPIC_SKILLS_API_KEY` |
| `slack_bot_token` | `BRIA_SLACKBOT_TOKEN` (unchanged) |

After merge, the docs-sync workflow is fully wired. Remaining prerequisite: the `ANTHROPIC_SKILLS_API_KEY` secret must exist on the repo (or org, shared to this repo). `RELEASE_TOKEN` and `BRIA_SLACKBOT_TOKEN` are already available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)